### PR TITLE
Remove Amazon S3 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,17 @@ Also if you are running behind nginx you want to add the following to your confi
 proxy_set_header   X-Forwarded-Proto  https;
 
 ## For S3 Image Upload
+
+If you use Amazon AWS S3:
 ```
 # To run with image upload to S3 enabled
 AWS_ACCESS_KEY_ID=XXX AWS_SECRET_ACCESS_KEY=XXX S3_BUCKET=my-test S3_REGION=eu-central-1 ./start
+```
+
+If you use an alternative to Amazon AWS S3:
+```
+# To run with image upload to a S3 alternative enabled
+AWS_ACCESS_KEY_ID=XXX AWS_SECRET_ACCESS_KEY=XXX S3_BUCKET=my-test S3_ENDPOINT=my.s3.website.com ./start
 ```
 
 You will need to have the imagemagick package installed.

--- a/server_api/controllers/images.js
+++ b/server_api/controllers/images.js
@@ -144,7 +144,7 @@ router.post('/', isAuthenticated, function(req, res) {
     if (error) {
       sendError(res, null, 'multerMultipartResolver', res.user, error);
     } else {
-      var s3UploadClient = models.Image.getUploadClient(process.env.S3_BUCKET, req.query.itemType);
+      var s3UploadClient = models.Image.getUploadClient(req.query.itemType);
       s3UploadClient.upload(req.file.path, {}, function(error, versions, meta) {
         if (error) {
           sendError(res, null, 's3UploadClient', res.user, error);

--- a/server_api/models/image.js
+++ b/server_api/models/image.js
@@ -53,7 +53,7 @@ module.exports = function(sequelize, DataTypes) {
         return formats;
       },
 
-      getUploadClient: function (s3BucketName, itemType) {
+      getUploadClient: function (itemType) {
         var versions;
 
         if (itemType && itemType === 'user-profile') {
@@ -242,9 +242,10 @@ module.exports = function(sequelize, DataTypes) {
           ]
         }
 
-        return new Upload(s3BucketName, {
+        return new Upload(process.env.S3_BUCKET, {
+          url: process.env.S3_URL || null,
           aws: {
-            region: process.env.S3_REGION ? process.env.S3_REGION : 'us-east-1',
+            region: process.env.S3_REGION || 'us-east-1',
             acl: 'public-read'
           },
 
@@ -290,7 +291,7 @@ module.exports = function(sequelize, DataTypes) {
                 log.error("Error when trying to write image", {err: error});
                 return done(err);
               }
-              var s3UploadClient = sequelize.models.Image.getUploadClient(process.env.S3_BUCKET, "user-profile");
+              var s3UploadClient = sequelize.models.Image.getUploadClient("user-profile");
               s3UploadClient.upload(filepath, {}, function(error, versions, meta) {
                 if (error) {
                   done(error);

--- a/server_api/models/image.js
+++ b/server_api/models/image.js
@@ -47,7 +47,9 @@ module.exports = function(sequelize, DataTypes) {
         versions.forEach(function(version) {
           var n = version.url.lastIndexOf(process.env.S3_BUCKET);
           var path = version.url.substring(n+process.env.S3_BUCKET.length, version.url.length);
-          var newUrl = "https://"+process.env.S3_BUCKET+".s3.amazonaws.com"+path;
+          var newUrl = "https://"
+            + process.env.S3_BUCKET + "." + (process.env.S3_ENDPOINT || "s3.amazonaws.com")
+            + path;
           formats.push(newUrl);
         });
         return formats;
@@ -243,9 +245,9 @@ module.exports = function(sequelize, DataTypes) {
         }
 
         return new Upload(process.env.S3_BUCKET, {
-          url: process.env.S3_URL || null,
           aws: {
-            region: process.env.S3_REGION || 'us-east-1',
+            endpoint: process.env.S3_ENDPOINT || null,
+            region: process.env.S3_REGION || (process.env.S3_ENDPOINT ? null : 'us-east-1'),
             acl: 'public-read'
           },
 

--- a/server_api/scripts/importDomain.js
+++ b/server_api/scripts/importDomain.js
@@ -261,7 +261,7 @@ var changePostCounter = function (req, postId, column, upDown, next) {
 };
 
 var s3Upload = function(filePath, itemType, userId, callback) {
-  var s3UploadClient = models.Image.getUploadClient(process.env.S3_BUCKET, itemType);
+  var s3UploadClient = models.Image.getUploadClient(itemType);
   s3UploadClient.upload(filePath, {}, function(error, versions, meta) {
     console.log("Uploading tried: "+error+" "+versions);
     if (error) {


### PR DESCRIPTION
Allow to upload images to any S3 compatible server. 

Tested with open source Zenko CloudServer.