### PR TITLE
Fix for category size problem

### DIFF
--- a/client_app/src/yp-post/yp-post-cover-media.html
+++ b/client_app/src/yp-post/yp-post-cover-media.html
@@ -324,16 +324,22 @@
       },
 
       _isCategoryActive: function (post) {
-        if (this._withCoverMediaType(post, 'category') && post.id<=11000)
+        if (post && this._withCoverMediaType(post, 'category') && (post.id<=11000 && this._isDomainWithOldCategories()))
           return true;
         else
           return false
       },
 
+      _isDomainWithOldCategories: function () {
+        // Workaround to support old square category images on Citizens Foundation websites running since 2010
+        var hostname = window.location.hostname;
+        return (hostname.indexOf("betrireykjavik.is") >-1 ||
+                hostname.indexOf("betraisland.is") >-1 ||
+                hostname.indexOf("yrpri.org") >-1)
+      },
 
-      // We switch over to 100% category images
       _isCategoryLargeActive: function (post) {
-        if (post && this._withCoverMediaType(post, 'category') && post.id>11000)
+        if (post && this._withCoverMediaType(post, 'category') && (post.id>11000 || !this._isDomainWithOldCategories()))
           return true;
         else
           return false


### PR DESCRIPTION
Since old Citizens Foundation websites used a smaller square image format there is a feature to display the old style images. Originally this was hacked using only the id of the post to find if the system should display the old or new category images. On new websites using Your Priorities this would not work so in this PR we explicitly check if the app is running on the three Citizens Foundation websites that still have have posts that use the old category image format. 