### PR TITLE
Add showItemCount setting

### DIFF
--- a/server_api/dist/controllers/communities.cjs
+++ b/server_api/dist/controllers/communities.cjs
@@ -729,6 +729,7 @@ const updateCommunityConfigParameters = function (req, community) {
     community.set("configuration.disableGroupDynamicFontSizes", truthValueFromBody(req.body.disableGroupDynamicFontSizes));
     community.set("configuration.hideGroupListCardObjectives", truthValueFromBody(req.body.hideGroupListCardObjectives));
     community.set("configuration.alwaysHideLogoImage", truthValueFromBody(req.body.alwaysHideLogoImage));
+    community.set("configuration.showItemCount", truthValueFromBody(req.body.showItemCount));
     community.set("configuration.recalculateCountersRecursively", truthValueFromBody(req.body.recalculateCountersRecursively));
     if (req.body.google_analytics_code && req.body.google_analytics_code != "") {
         community.google_analytics_code = req.body.google_analytics_code;

--- a/server_api/dist/controllers/domains.cjs
+++ b/server_api/dist/controllers/domains.cjs
@@ -854,6 +854,7 @@ function updateDomainProperties(domain, req) {
     domain.set('configuration.hideDomainNews', truthValueFromBody(req.body.hideDomainNews));
     domain.set('configuration.hideDomainTabs', truthValueFromBody(req.body.hideDomainTabs));
     domain.set('configuration.hideAllTabs', truthValueFromBody(req.body.hideAllTabs));
+    domain.set('configuration.showItemCount', truthValueFromBody(req.body.showItemCount));
     domain.set('configuration.useFixedTopAppBar', truthValueFromBody(req.body.useFixedTopAppBar));
     domain.set('configuration.disableArrowBasedTopNavigation', truthValueFromBody(req.body.disableArrowBasedTopNavigation));
     domain.set('configuration.onlyAllowCreateUserOnInvite', truthValueFromBody(req.body.onlyAllowCreateUserOnInvite));

--- a/server_api/dist/controllers/groups.cjs
+++ b/server_api/dist/controllers/groups.cjs
@@ -287,6 +287,7 @@ var updateGroupConfigParameters = function (req, group) {
     group.set("configuration.showNameUnderLogoImage", truthValueFromBody(req.body.showNameUnderLogoImage));
     group.set("configuration.alwaysHideLogoImage", truthValueFromBody(req.body.alwaysHideLogoImage));
     group.set("configuration.hideStatsAndMembership", truthValueFromBody(req.body.hideStatsAndMembership));
+    group.set("configuration.showItemCount", truthValueFromBody(req.body.showItemCount));
     group.set("configuration.centerGroupName", truthValueFromBody(req.body.centerGroupName));
     group.set("configuration.noGroupCardShadow", truthValueFromBody(req.body.noGroupCardShadow));
     group.set("configuration.hideNewestFromFilter", truthValueFromBody(req.body.hideNewestFromFilter));

--- a/server_api/src/controllers/communities.cjs
+++ b/server_api/src/controllers/communities.cjs
@@ -886,6 +886,10 @@ const updateCommunityConfigParameters = function (req, community) {
     "configuration.alwaysHideLogoImage",
     truthValueFromBody(req.body.alwaysHideLogoImage)
   );
+  community.set(
+    "configuration.showItemCount",
+    truthValueFromBody(req.body.showItemCount)
+  );
 
   community.set(
     "configuration.recalculateCountersRecursively",

--- a/server_api/src/controllers/domains.cjs
+++ b/server_api/src/controllers/domains.cjs
@@ -877,6 +877,7 @@ function updateDomainProperties(domain, req) {
   domain.set('configuration.hideDomainNews', truthValueFromBody(req.body.hideDomainNews));
   domain.set('configuration.hideDomainTabs', truthValueFromBody(req.body.hideDomainTabs));
   domain.set('configuration.hideAllTabs', truthValueFromBody(req.body.hideAllTabs));
+  domain.set('configuration.showItemCount', truthValueFromBody(req.body.showItemCount));
 
   domain.set('configuration.useFixedTopAppBar', truthValueFromBody(req.body.useFixedTopAppBar));
   domain.set('configuration.disableArrowBasedTopNavigation', truthValueFromBody(req.body.disableArrowBasedTopNavigation));

--- a/server_api/src/controllers/groups.cjs
+++ b/server_api/src/controllers/groups.cjs
@@ -524,6 +524,10 @@ var updateGroupConfigParameters = function (req, group) {
     truthValueFromBody(req.body.hideStatsAndMembership)
   );
   group.set(
+    "configuration.showItemCount",
+    truthValueFromBody(req.body.showItemCount)
+  );
+  group.set(
     "configuration.centerGroupName",
     truthValueFromBody(req.body.centerGroupName)
   );

--- a/webApps/client/locales/en/translation.json
+++ b/webApps/client/locales/en/translation.json
@@ -359,6 +359,7 @@
   "noGroupCardShadow": "No group card shadow",
   "centerGroupName": "Center group name in lists",
   "hideStatsAndMembership": "Hide stats and membership in lists",
+  "showItemCount": "Show item count",
   "showNameUnderLogoImage": "Show name under logo image",
   "galleryMode": "Gallery mode",
   "muteNotificationsForEndorsements": "Mute notifications for endorsements",

--- a/webApps/client/src/admin/yp-admin-config-community.ts
+++ b/webApps/client/src/admin/yp-admin-config-community.ts
@@ -1054,6 +1054,12 @@ export class YpAdminConfigCommunity extends YpAdminConfigBase {
           maxLength: 200,
         },
         {
+          text: "showItemCount",
+          type: "checkbox",
+          value: this.collection?.configuration.showItemCount,
+          translationToken: "showItemCount",
+        },
+        {
           text: "customBackName",
           type: "textfield",
           maxLength: 20,

--- a/webApps/client/src/admin/yp-admin-config-domain.ts
+++ b/webApps/client/src/admin/yp-admin-config-domain.ts
@@ -319,6 +319,12 @@ export class YpAdminConfigDomain extends YpAdminConfigBase {
           type: "checkbox",
         },
         {
+          text: "showItemCount",
+          type: "checkbox",
+          value: this.collection?.configuration.showItemCount,
+          translationToken: "showItemCount",
+        },
+        {
           text: "hideDomainNews",
           type: "checkbox",
         },

--- a/webApps/client/src/admin/yp-admin-config-group.ts
+++ b/webApps/client/src/admin/yp-admin-config-group.ts
@@ -1524,6 +1524,12 @@ export class YpAdminConfigGroup extends YpAdminConfigBase {
           translationToken: "hideStatsAndMembership",
         },
         {
+          text: "showItemCount",
+          type: "checkbox",
+          value: this.group.configuration.showItemCount,
+          translationToken: "showItemCount",
+        },
+        {
           text: "customBackURL",
           type: "textfield",
           maxLength: 256,

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -75,6 +75,7 @@ interface YpCollectionConfiguration {
   customBackName?: string;
   customBackURL?: string;
   hideAllTabs?: boolean;
+  showItemCount?: boolean;
   highlightedLanguages?: string;
 }
 

--- a/webApps/client/src/yp-collection/yp-collection-item-card.ts
+++ b/webApps/client/src/yp-collection/yp-collection-item-card.ts
@@ -396,13 +396,12 @@ export class YpCollectionItemCard extends YpBaseElement {
           .content="${this.contentName}"
           .contentId="${this.contentId}"
         ></yp-magic-text>
-        ${this.collectionItemCount > 0
-          ? html`
-              <div class="collectionItemCount">
-                (${this.collectionItemCount})
-              </div>
-            `
-          : nothing}
+        ${
+          this.collectionItemCount > 0 &&
+          (this.collection?.configuration?.showItemCount ?? true)
+            ? html`<div class="collectionItemCount">(${this.collectionItemCount})</div>`
+            : nothing
+        }
       </div>
     `;
   }

--- a/webApps/land_use_game/src/@yrpri/types.d.ts
+++ b/webApps/land_use_game/src/@yrpri/types.d.ts
@@ -18,6 +18,7 @@ interface YpCollectionConfiguration {
   customBackName?: string;
   customBackURL?: string;
   hideAllTabs?: boolean;
+  showItemCount?: boolean;
   highlightedLanguages?: string;
 }
 

--- a/webApps/old/ai_assistant/src/@yrpri/types.d.ts
+++ b/webApps/old/ai_assistant/src/@yrpri/types.d.ts
@@ -18,6 +18,7 @@ interface YpCollectionConfiguration {
   customBackName?: string;
   customBackURL?: string;
   hideAllTabs?: boolean;
+  showItemCount?: boolean;
   highlightedLanguages?: string;
 }
 

--- a/webApps/old/promotion_app/src/@yrpri/types.d.ts
+++ b/webApps/old/promotion_app/src/@yrpri/types.d.ts
@@ -18,6 +18,7 @@ interface YpCollectionConfiguration {
   customBackName?: string;
   customBackURL?: string;
   hideAllTabs?: boolean;
+  showItemCount?: boolean;
   highlightedLanguages?: string;
 }
 


### PR DESCRIPTION
## Summary
- allow configuration to show or hide collection item counts
- render item count conditionally in collection item cards
- expose setting in admin screens for groups, communities and domains
- update API controllers to persist the new field
- provide English translation for the setting

## Testing
- `npm run lint` *(fails: lit-analyzer not found)*
- `npm test` *(fails: wtr not found)*