### PR TITLE
Add alphabetical sort option for collections

### DIFF
--- a/server_api/src/controllers/communities.cjs
+++ b/server_api/src/controllers/communities.cjs
@@ -1036,6 +1036,10 @@ const updateCommunityConfigParameters = function (req, community) {
     truthValueFromBody(req.body.sortBySortOrder)
   );
   community.set(
+    "configuration.sortAlphabetically",
+    truthValueFromBody(req.body.sortAlphabetically)
+  );
+  community.set(
     "configuration.orderByRandom",
     truthValueFromBody(req.body.orderByRandom)
   );

--- a/webApps/client/dist/locales/en/translation.json
+++ b/webApps/client/dist/locales/en/translation.json
@@ -491,6 +491,7 @@
   "highlightedLanguages": "Highlighted locales (en,is,fr)",
   "optionalSortOrder": "Optional sort order",
   "sortGroupsBySortOrder": "Sort groups by sort order",
+  "sortGroupsAlphabetically": "Sort groups alphabetically",
   "openAnalyticsApp": "Open Analytics App",
   "sendInviteByEmail": "Send invite by email",
   "addUserDirectlyIfExist": "Add user if exist",

--- a/webApps/client/locales/en/translation.json
+++ b/webApps/client/locales/en/translation.json
@@ -491,6 +491,7 @@
   "highlightedLanguages": "Highlighted locales (en,is,fr)",
   "optionalSortOrder": "Optional sort order",
   "sortGroupsBySortOrder": "Sort groups by sort order",
+  "sortGroupsAlphabetically": "Sort groups alphabetically",
   "openAnalyticsApp": "Open Analytics App",
   "sendInviteByEmail": "Send invite by email",
   "addUserDirectlyIfExist": "Add user if exist",

--- a/webApps/client/src/admin/yp-admin-config-community.ts
+++ b/webApps/client/src/admin/yp-admin-config-community.ts
@@ -1049,6 +1049,11 @@ export class YpAdminConfigCommunity extends YpAdminConfigBase {
           translationToken: "sortGroupsBySortOrder",
         },
         {
+          text: "sortAlphabetically",
+          type: "checkbox",
+          translationToken: "sortGroupsAlphabetically",
+        },
+        {
           text: "highlightedLanguages",
           type: "textfield",
           maxLength: 200,

--- a/webApps/client/src/common/YpCollectionHelpers.ts
+++ b/webApps/client/src/common/YpCollectionHelpers.ts
@@ -13,6 +13,14 @@ export class YpCollectionHelpers {
       } catch (e) {
         console.error(e);
       }
+    } else if (containerConfig && containerConfig.sortAlphabetically) {
+      try {
+        items = items.sort((a, b) => {
+          return (a.name || '').localeCompare(b.name || '');
+        });
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     return {

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -69,6 +69,7 @@ interface YpCollectionConfiguration {
   useVideoCover?: boolean;
   welcomeHTML?: string;
   sortBySortOrder?: boolean;
+  sortAlphabetically?: boolean;
   optionalSortOrder?: number;
   locationHidden?: boolean;
   welcomePageId?: number;

--- a/webApps/land_use_game/dist/locales/en/translation.json
+++ b/webApps/land_use_game/dist/locales/en/translation.json
@@ -150,6 +150,7 @@
   "highlightedLanguages": "Highlighted locales (en,is,fr)",
   "optionalSortOrder": "Optional sort order",
   "sortGroupsBySortOrder": "Sort groups by sort order",
+  "sortGroupsAlphabetically": "Sort groups alphabetically",
   "openAnalyticsApp": "Open Analytics App",
   "sendInviteByEmail": "Send invite by email",
   "addUserDirectlyIfExist": "Add user if exist",

--- a/webApps/land_use_game/locales/en/translation.json
+++ b/webApps/land_use_game/locales/en/translation.json
@@ -150,6 +150,7 @@
   "highlightedLanguages": "Highlighted locales (en,is,fr)",
   "optionalSortOrder": "Optional sort order",
   "sortGroupsBySortOrder": "Sort groups by sort order",
+  "sortGroupsAlphabetically": "Sort groups alphabetically",
   "openAnalyticsApp": "Open Analytics App",
   "sendInviteByEmail": "Send invite by email",
   "addUserDirectlyIfExist": "Add user if exist",

--- a/webApps/land_use_game/src/@yrpri/common/YpCollectionHelpers.ts
+++ b/webApps/land_use_game/src/@yrpri/common/YpCollectionHelpers.ts
@@ -13,6 +13,14 @@ export class YpCollectionHelpers {
       } catch (e) {
         console.error(e);
       }
+    } else if (containerConfig && containerConfig.sortAlphabetically) {
+      try {
+        items = items.sort((a, b) => {
+          return (a.name || '').localeCompare(b.name || '');
+        });
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     return {

--- a/webApps/land_use_game/src/@yrpri/types.d.ts
+++ b/webApps/land_use_game/src/@yrpri/types.d.ts
@@ -12,6 +12,7 @@ interface YpCollectionConfiguration {
   useVideoCover?: boolean;
   welcomeHTML?: string;
   sortBySortOrder?: boolean;
+  sortAlphabetically?: boolean;
   optionalSortOrder?: number;
   locationHidden?: boolean;
   welcomePageId?: number;

--- a/webApps/old/ai_assistant/src/@yrpri/common/YpCollectionHelpers.ts
+++ b/webApps/old/ai_assistant/src/@yrpri/common/YpCollectionHelpers.ts
@@ -13,6 +13,14 @@ export class YpCollectionHelpers {
       } catch (e) {
         console.error(e);
       }
+    } else if (containerConfig && containerConfig.sortAlphabetically) {
+      try {
+        items = items.sort((a, b) => {
+          return (a.name || '').localeCompare(b.name || '');
+        });
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     return {

--- a/webApps/old/ai_assistant/src/@yrpri/types.d.ts
+++ b/webApps/old/ai_assistant/src/@yrpri/types.d.ts
@@ -12,6 +12,7 @@ interface YpCollectionConfiguration {
   useVideoCover?: boolean;
   welcomeHTML?: string;
   sortBySortOrder?: boolean;
+  sortAlphabetically?: boolean;
   optionalSortOrder?: number;
   locationHidden?: boolean;
   welcomePageId?: number;

--- a/webApps/old/client/build/bundled/locales/en/translation.json
+++ b/webApps/old/client/build/bundled/locales/en/translation.json
@@ -138,6 +138,7 @@
   "highlightedLanguages": "Highlighted locales (en,is,fr)",
   "optionalSortOrder": "Optional sort order",
   "sortGroupsBySortOrder": "Sort groups by sort order",
+  "sortGroupsAlphabetically": "Sort groups alphabetically",
   "openAnalyticsApp": "Open Analytics App",
   "sendInviteByEmail": "Send invite by email",
   "addUserDirectlyIfExist": "Add user if exist",

--- a/webApps/old/client/locales/en/translation.json
+++ b/webApps/old/client/locales/en/translation.json
@@ -138,6 +138,7 @@
   "highlightedLanguages": "Highlighted locales (en,is,fr)",
   "optionalSortOrder": "Optional sort order",
   "sortGroupsBySortOrder": "Sort groups by sort order",
+  "sortGroupsAlphabetically": "Sort groups alphabetically",
   "openAnalyticsApp": "Open Analytics App",
   "sendInviteByEmail": "Send invite by email",
   "addUserDirectlyIfExist": "Add user if exist",

--- a/webApps/old/client/src/yp-behaviors/collection-helpers.html
+++ b/webApps/old/client/src/yp-behaviors/collection-helpers.html
@@ -21,6 +21,14 @@
          } catch (e) {
            console.error(e);
          }
+      } else if (containerConfig && containerConfig.sortAlphabetically) {
+         try {
+           items = items.sort(function (a, b) {
+             return (a.name || '').localeCompare(b.name || '');
+           });
+         } catch (e) {
+           console.error(e);
+         }
       }
       return {
         active: __.filter(items, function (o) {

--- a/webApps/old/promotion_app/src/@yrpri/common/YpCollectionHelpers.ts
+++ b/webApps/old/promotion_app/src/@yrpri/common/YpCollectionHelpers.ts
@@ -13,6 +13,14 @@ export class YpCollectionHelpers {
       } catch (e) {
         console.error(e);
       }
+    } else if (containerConfig && containerConfig.sortAlphabetically) {
+      try {
+        items = items.sort((a, b) => {
+          return (a.name || '').localeCompare(b.name || '');
+        });
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     return {

--- a/webApps/old/promotion_app/src/@yrpri/types.d.ts
+++ b/webApps/old/promotion_app/src/@yrpri/types.d.ts
@@ -12,6 +12,7 @@ interface YpCollectionConfiguration {
   useVideoCover?: boolean;
   welcomeHTML?: string;
   sortBySortOrder?: boolean;
+  sortAlphabetically?: boolean;
   optionalSortOrder?: number;
   locationHidden?: boolean;
   welcomePageId?: number;


### PR DESCRIPTION
## Summary
- support alphabetical sorting in YpCollectionHelpers
- extend collection configuration interface with `sortAlphabetically`
- expose flag in admin UI and translations
- store setting from API controller

## Testing
- `npm test` *(fails: wtr not found)*