### PR TITLE
Add alt text to fallback images

### DIFF
--- a/webApps/client/src/admin/yp-admin-app.ts
+++ b/webApps/client/src/admin/yp-admin-app.ts
@@ -1240,6 +1240,7 @@ export class YpAdminApp extends YpBaseElement {
               <yp-image
                 class="collectionLogoImage"
                 sizing="contain"
+                .alt="${this.collection?.name}"
                 .src="${this.collection
                   ? YpCollectionHelpers.logoImagePath(
                       this.collectionType,

--- a/webApps/client/src/admin/yp-admin-communities.ts
+++ b/webApps/client/src/admin/yp-admin-communities.ts
@@ -79,6 +79,7 @@ export class YpAdminCommunities extends YpBaseElementWithLogin {
         <yp-image
           class="mainImage"
           sizing="contain"
+          .alt="${community.name}"
           .src="${communityImage}"
         ></yp-image>
         <div class="layout vertical">

--- a/webApps/client/src/admin/yp-admin-config-base.ts
+++ b/webApps/client/src/admin/yp-admin-config-base.ts
@@ -574,6 +574,7 @@ export abstract class YpAdminConfigBase extends YpAdminPage {
             @loaded="${this.getColorFromLogo}"
             sizing="cover"
             .skipCloudFlare="${true}"
+            .alt="${this.collection?.name}"
             src="${this.imagePreviewUrl}"
           ></yp-image>
           ${this.gettingImageColor
@@ -592,6 +593,7 @@ export abstract class YpAdminConfigBase extends YpAdminPage {
           <yp-image
             class="image"
             sizing="cover"
+            .alt="${this.collection?.name}"
             src="${YpMediaHelpers.getImageFormatUrl(this.currentLogoImages)}"
           ></yp-image>
           ${this.gettingImageColor
@@ -609,6 +611,7 @@ export abstract class YpAdminConfigBase extends YpAdminPage {
         <yp-image
           class="image"
           sizing="contain"
+          .alt="${this.collection?.name}"
           src="https://yrpri-eu-direct-assets.s3.eu-west-1.amazonaws.com/ypPlaceHolder2.jpg"
         ></yp-image>
       `;

--- a/webApps/client/src/admin/yp-admin-groups.ts
+++ b/webApps/client/src/admin/yp-admin-groups.ts
@@ -77,6 +77,7 @@ export class YpAdminGroups extends YpBaseElementWithLogin {
         <yp-image
           class="mainImage"
           sizing="contain"
+          .alt="${group.name}"
           .src="${groupImage}"
         ></yp-image>
         <div class="layout vertical">

--- a/webApps/client/src/allOurIdeas/survey/aoi-survey-intro.ts
+++ b/webApps/client/src/allOurIdeas/survey/aoi-survey-intro.ts
@@ -236,6 +236,7 @@ export class AoiSurveyIntro extends YpBaseElement {
           <yp-image
             class="column image"
             sizing="contain"
+            .alt="${this.group.name}"
             src="${YpMediaHelpers.getImageFormatUrl(
               this.group.GroupLogoImages
             )}"

--- a/webApps/client/src/analytics-and-promotion/yp-analytics/yp-campaign-analysis.ts
+++ b/webApps/client/src/analytics-and-promotion/yp-analytics/yp-campaign-analysis.ts
@@ -110,6 +110,7 @@ export class YpCampaignAnalysis extends YpCampaign {
           <yp-image
             class="mediumImage"
             sizing="contain"
+            .alt="${medium.utm_medium}"
             .src="${this.getMediumImageUrl(medium.utm_medium)}"
           >
           </yp-image>

--- a/webApps/client/src/analytics-and-promotion/yp-promotion-app.ts
+++ b/webApps/client/src/analytics-and-promotion/yp-promotion-app.ts
@@ -324,6 +324,7 @@ export class YpPromotionApp extends YpBaseElementWithLogin {
                 <yp-image
                   class="collectionLogoImage"
                   sizing="contain"
+                  .alt="${this.collection?.name}"
                   .src="${YpCollectionHelpers.logoImagePath(
                     this.collectionType,
                     this.collection!

--- a/webApps/client/src/analytics-and-promotion/yp-promotion/yp-campaign.ts
+++ b/webApps/client/src/analytics-and-promotion/yp-promotion/yp-campaign.ts
@@ -336,6 +336,7 @@ export class YpCampaign extends YpBaseElementWithLogin {
             <yp-image
               sizing="cover"
               class="mediumActivationImage"
+              .alt="${this.mediumToActivate!.utm_medium}"
               .src="${this.getMediumImageUrl(
                 this.mediumToActivate!.utm_medium
               )}"
@@ -384,6 +385,7 @@ export class YpCampaign extends YpBaseElementWithLogin {
             <yp-image
               sizing="cover"
               class="mediumActivationImage mediumShowImage"
+              .alt="${this.mediumToShow!.utm_medium}"
               .src="${this.getMediumImageUrl(this.mediumToShow!.utm_medium)}"
             >
             </yp-image>
@@ -413,6 +415,7 @@ export class YpCampaign extends YpBaseElementWithLogin {
           <yp-image
             class="mediumImage"
             sizing="contain"
+            .alt="${medium.utm_medium}"
             .src="${this.getMediumImageUrl(medium.utm_medium)}"
           >
           </yp-image>

--- a/webApps/client/src/analytics-and-promotion/yp-promotion/yp-new-campaign.ts
+++ b/webApps/client/src/analytics-and-promotion/yp-promotion/yp-new-campaign.ts
@@ -403,6 +403,7 @@ export class YpNewCampaign extends YpBaseElementWithLogin {
             <yp-image
               class="collectionLogoImage"
               sizing="cover"
+              .alt="${this.collection?.name}"
               .src="${this.collectionImageUrl}"
             ></yp-image>
           </div>

--- a/webApps/client/src/yp-collection/yp-collection-item-card.ts
+++ b/webApps/client/src/yp-collection/yp-collection-item-card.ts
@@ -347,6 +347,7 @@ export class YpCollectionItemCard extends YpBaseElement {
             <yp-image
               ?archived="${this.archived}"
               sizing="cover"
+              .alt="${this.collection!.name}"
               class="main-image withPointer"
               src="https://i.imgur.com/sdsFAoT.png"
             ></yp-image>

--- a/webApps/client/src/yp-point/yp-point-news-story-embed.ts
+++ b/webApps/client/src/yp-point/yp-point-news-story-embed.ts
@@ -68,6 +68,7 @@ export class YpPointNewsStoryEmbed extends YpBaseElement {
                   <yp-image
                     sizing="contain"
                     src="${this.embedData.thumbnail_url}"
+                    .alt="${this.embedData.title}"
                     ?hidden="${this.embedData.html != null}"></yp-image>
                   <div id="embedHtml" ?hidden="${!this.embedData.html}">
                     <div .inner-h-t-m-l="${this.embedData}"></div>

--- a/webApps/client/src/yp-post/yp-post-cover-media.ts
+++ b/webApps/client/src/yp-post/yp-post-cover-media.ts
@@ -323,6 +323,7 @@ export class YpPostCoverMedia extends YpBaseElement {
               <yp-image
                 ?header-mode="${this.headerMode}"
                 sizing="cover"
+                .alt="${ifDefined(this.altTag || this.post?.name)}"
                 ?hidden="${this.defaultPostImageEnabled}"
                 class="main-image pointer"
                 src="https://i.imgur.com/sdsFAoT.png"
@@ -406,6 +407,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                         ?headerMode="${this.headerMode}"
                         @click="${this._goToPost}"
                         sizing="cover"
+                        .alt="${ifDefined(this.altTag || this.post?.name)}"
                         class="main-image pointer"
                         src="${this.postVideoPosterPath}"></yp-image>
                     </div>
@@ -460,6 +462,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                       @click="${this._goToPost}"
                       class="main-image pointer"
                       sizing="cover"
+                      .alt="${ifDefined(this.altTag || this.post?.name)}"
                       src="https://maps.googleapis.com/maps/api/staticmap?center=${this.latitude},${this.longitude}&amp;zoom=${this.zoomLevel}&amp;size=432x243&amp;maptype=hybrid&amp;markers=color:red%7Clabel:%7C${this.latitude},${this.longitude}&amp;key=${this.staticMapsApiKey}"
                       ?hidden="${this.streetViewActivated}"></yp-image>
 
@@ -483,6 +486,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                       class="main-image pointer"
                       ?hidden="${this.mapActivated}"
                       sizing="cover"
+                      .alt="${ifDefined(this.altTag || this.post?.name)}"
                       src="https://maps.googleapis.com/maps/api/staticmap?center=${this.latitude},${this.longitude}&amp;size=432x243&amp;zoom=${this.zoomLevel}&amp;maptype=${this.mapType}&amp;markers=color:red%7Clabel:%7C${this.latitude},${this.longitude}&amp;key=${this.staticMapsApiKey}"></yp-image>
 
                     ${this.mapActivated

--- a/webApps/client/src/yp-post/yp-post-edit.ts
+++ b/webApps/client/src/yp-post/yp-post-edit.ts
@@ -748,6 +748,7 @@ export class YpPostEdit extends YpEditBase {
             class="image"
             sizing="cover"
             .skipCloudFlare="${true}"
+            .alt="${ifDefined(this.post?.name)}"
             src="${this.imagePreviewUrl}"
           ></yp-image>
         </div>
@@ -761,6 +762,7 @@ export class YpPostEdit extends YpEditBase {
           <yp-image
             class="image"
             sizing="cover"
+            .alt="${ifDefined(this.post?.name)}"
             src="${YpMediaHelpers.getImageFormatUrl(
               this.post?.PostHeaderImages
             )}"
@@ -772,6 +774,7 @@ export class YpPostEdit extends YpEditBase {
         <yp-image
           class="image"
           sizing="contain"
+          .alt="${ifDefined(this.post?.name)}"
           src="https://yrpri-eu-direct-assets.s3.eu-west-1.amazonaws.com/ypPlaceHolder2.jpg"
         ></yp-image>
       `;

--- a/webApps/client/src/yp-post/yp-posts-filter.ts
+++ b/webApps/client/src/yp-post/yp-posts-filter.ts
@@ -238,6 +238,7 @@ export class YpPostsFilter extends YpBaseElement {
                           class="catImage"
                           height="24"
                           width="24"
+                          .alt="${category.name}"
                           src="${this._categoryImageSrc(category)}"
                         ></yp-image>
                         ${category.name} (${category.count})


### PR DESCRIPTION
## Summary
- set `alt` text on fallback image in collection item card
- audit components for missing `alt` attributes
- add alt text for posts, campaigns, admin listings and others

## Testing
- `npm run lint` *(fails: lit-analyzer not found)*