### PR TITLE
Add theme background color support

### DIFF
--- a/webApps/client/docs/src/yp-app/YpThemeManager.md
+++ b/webApps/client/docs/src/yp-app/YpThemeManager.md
@@ -35,7 +35,7 @@ The `YpThemeManager` class is responsible for managing and applying themes, incl
 | sanitizeFontImports           | fontImports: string[]                                                      | string[]    | Sanitizes the given font import URLs to allow only certain domains.         |
 | applyFontStyles               | fontStyles: string \| null                                                 | void        | Applies the given font styles to the document.                              |
 | importFonts                   | fontImportsString: string \| null                                          | void        | Imports fonts from the given URLs into the document.                        |
-| setTheme                      | number: number \| undefined, configuration: YpCollectionConfiguration \| undefined | void        | Sets the theme based on the given configuration.                            |
+| setTheme                      | number: number \| undefined, configuration: YpCollectionConfiguration \| undefined | void        | Sets the theme based on the given configuration and applies the background color. |
 | updateBrowserThemeColor       | -                                                                          | void        | Updates the browser's theme color meta tag based on the current theme.      |
 | updateLiveFromConfiguration   | theme: YpThemeConfiguration                                                | void        | Updates the theme live from the given configuration.                        |
 | themeChanged                  | target: HTMLElement \| undefined                                           | void        | Applies the current theme settings to the document.                         |

--- a/webApps/client/docs/src/yp-theme/yp-theme-selector.md
+++ b/webApps/client/docs/src/yp-theme/yp-theme-selector.md
@@ -12,6 +12,7 @@ The `YpThemeSelector` is a web component that allows users to select and configu
 | themeTertiaryColor          | `string \| undefined`         | The tertiary color of the theme.                                            |
 | themeNeutralColor           | `string \| undefined`         | The neutral color of the theme.                                             |
 | themeNeutralVariantColor    | `string \| undefined`         | The neutral variant color of the theme.                                     |
+| themeBackgroundColor       | `string \| undefined`         | The background color of the theme.                                        |
 | fontStyles                  | `string \| undefined`         | The font styles to be applied to the theme.                                 |
 | fontImports                 | `string \| undefined`         | The font imports to be used in the theme.                                   |
 | selectedThemeScheme         | `string`                      | The selected theme scheme, default is "tonal".                              |

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -58,6 +58,7 @@ interface YpThemeConfiguration {
   iconPrompt?: string;
   fontStyles?: string;
   fontImports?: string;
+  backgroundColor?: string;
 }
 
 interface YpCollectionConfiguration {

--- a/webApps/client/src/yp-app/YpThemeManager.ts
+++ b/webApps/client/src/yp-app/YpThemeManager.ts
@@ -528,6 +528,11 @@ export class YpThemeManager {
         this.importFonts(null);
       }
 
+      if (configuration.theme.backgroundColor) {
+        const bg = configuration.theme.backgroundColor;
+        document.body.style.backgroundColor = bg.startsWith('#') ? bg : `#${bg}`;
+      }
+
       this.themeChanged();
 
       this.updateBrowserThemeColor();

--- a/webApps/client/src/yp-theme/yp-theme-selector.ts
+++ b/webApps/client/src/yp-theme/yp-theme-selector.ts
@@ -37,6 +37,9 @@ export class YpThemeSelector extends YpBaseElement {
   themeNeutralVariantColor: string | undefined;
 
   @property({ type: String })
+  themeBackgroundColor: string | undefined;
+
+  @property({ type: String })
   fontStyles: string | undefined;
 
   @property({ type: String })
@@ -169,6 +172,7 @@ export class YpThemeSelector extends YpBaseElement {
       this.themeNeutralColor = this.themeConfiguration.neutralColor;
       this.themeNeutralVariantColor =
         this.themeConfiguration.neutralVariantColor;
+      this.themeBackgroundColor = this.themeConfiguration.backgroundColor;
       this.useLowestContainerSurface =
         this.themeConfiguration.useLowestContainerSurface || false;
 
@@ -208,6 +212,7 @@ export class YpThemeSelector extends YpBaseElement {
       "themeTertiaryColor",
       "themeNeutralColor",
       "themeNeutralVariantColor",
+      "themeBackgroundColor",
       "useLowestContainerSurface",
       "fontStyles",
       "fontImports",
@@ -233,6 +238,7 @@ export class YpThemeSelector extends YpBaseElement {
         tertiaryColor: this.themeTertiaryColor,
         neutralColor: this.themeNeutralColor,
         neutralVariantColor: this.themeNeutralVariantColor,
+        backgroundColor: this.themeBackgroundColor,
         useLowestContainerSurface: this.useLowestContainerSurface,
         fontStyles: this.fontStyles,
         fontImports: this.fontImports,
@@ -299,6 +305,7 @@ export class YpThemeSelector extends YpBaseElement {
       this.themeTertiaryColor,
       this.themeNeutralColor,
       this.themeNeutralVariantColor,
+      this.themeBackgroundColor,
     ].some((color) => this.isValidHex(color));
 
     this.disableMultiInputs = this.isValidHex(this.oneDynamicThemeColor);
@@ -434,6 +441,17 @@ export class YpThemeSelector extends YpBaseElement {
               .disableSelection="${this.disableMultiInputs}"
               @input="${(e: any) => {
                 this.themeNeutralVariantColor = e.detail.color;
+              }}"
+            >
+            </yp-theme-color-input>
+
+            <yp-theme-color-input
+              class="mainInput"
+              .label="${this.t("Theme Background Color")}"
+              .color="${this.themeBackgroundColor}"
+              .disableSelection="${this.disableMultiInputs}"
+              @input="${(e: any) => {
+                this.themeBackgroundColor = e.detail.color;
               }}"
             >
             </yp-theme-color-input>


### PR DESCRIPTION
## Summary
- allow setting a `backgroundColor` in `YpThemeConfiguration`
- apply configured background color in `YpThemeManager.setTheme`
- update theme selector component to edit the background color
- document new configuration option

## Testing
- `npm test` *(fails: wtr not found)*
- `npm run lint` *(fails: lit-analyzer not found)*