### PR TITLE
Update archived item visual style

### DIFF
--- a/webApps/client/docs/screenshots/after.svg
+++ b/webApps/client/docs/screenshots/after.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect width="200" height="100" fill="#f0f0f0"/>
+  <text x="100" y="55" font-size="20" text-anchor="middle" fill="#333">After</text>
+</svg>

--- a/webApps/client/docs/screenshots/before.svg
+++ b/webApps/client/docs/screenshots/before.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect width="200" height="100" fill="#f0f0f0"/>
+  <text x="100" y="55" font-size="20" text-anchor="middle" fill="#333">Before</text>
+</svg>

--- a/webApps/client/src/yp-collection/yp-collection-item-card.ts
+++ b/webApps/client/src/yp-collection/yp-collection-item-card.ts
@@ -127,6 +127,12 @@ export class YpCollectionItemCard extends YpBaseElement {
         }
 
         yp-image[archived] {
+          filter: grayscale(100%);
+          opacity: 0.6;
+        }
+
+        :host([archived]) {
+          opacity: 0.6;
         }
 
         yp-membership-button {
@@ -229,9 +235,8 @@ export class YpCollectionItemCard extends YpBaseElement {
     ];
   }
 
-  get archived(): boolean {
-    return this.item?.status === "archived";
-  }
+  @property({ type: Boolean, reflect: true })
+  archived = false;
 
   get featured(): boolean {
     return this.item?.status === "featured";
@@ -318,6 +323,10 @@ export class YpCollectionItemCard extends YpBaseElement {
 
   override updated(changedProperties: Map<string | number | symbol, unknown>) {
     super.updated(changedProperties);
+
+    if (changedProperties.has("item")) {
+      this.archived = this.item?.status === "archived";
+    }
 
     if (changedProperties.has("collection") && this.collection) {
       //TODO: Check if we need to setTimeout here


### PR DESCRIPTION
## Summary
- style archived item card hosts and images with reduced opacity
- expose `archived` as a reflected property
- update component logic to sync the new property
- add placeholder screenshots

## Testing
- `npm test` *(fails: `wtr` not found)*