### PR TITLE
Add domain-level alphabetical sort option

### DIFF
--- a/server_api/src/controllers/domains.cjs
+++ b/server_api/src/controllers/domains.cjs
@@ -879,6 +879,11 @@ function updateDomainProperties(domain, req) {
   domain.set('configuration.hideAllTabs', truthValueFromBody(req.body.hideAllTabs));
   domain.set('configuration.hideItemCount', truthValueFromBody(req.body.hideItemCount));
 
+  domain.set(
+    'configuration.sortAlphabetically',
+    truthValueFromBody(req.body.sortAlphabetically)
+  );
+
   domain.set('configuration.useFixedTopAppBar', truthValueFromBody(req.body.useFixedTopAppBar));
   domain.set('configuration.disableArrowBasedTopNavigation', truthValueFromBody(req.body.disableArrowBasedTopNavigation));
 

--- a/webApps/client/locales/en/translation.json
+++ b/webApps/client/locales/en/translation.json
@@ -493,6 +493,7 @@
   "optionalSortOrder": "Optional sort order",
   "sortGroupsBySortOrder": "Sort groups by sort order",
   "sortGroupsAlphabetically": "Sort groups alphabetically",
+  "sortCommunitiesAlphabetically": "Sort communities alphabetically",
   "openAnalyticsApp": "Open Analytics App",
   "sendInviteByEmail": "Send invite by email",
   "addUserDirectlyIfExist": "Add user if exist",

--- a/webApps/client/src/admin/yp-admin-config-domain.ts
+++ b/webApps/client/src/admin/yp-admin-config-domain.ts
@@ -325,6 +325,11 @@ export class YpAdminConfigDomain extends YpAdminConfigBase {
           translationToken: "hideItemCount",
         },
         {
+          text: "sortAlphabetically",
+          type: "checkbox",
+          translationToken: "sortCommunitiesAlphabetically",
+        },
+        {
           text: "hideDomainNews",
           type: "checkbox",
         },


### PR DESCRIPTION
## Summary
- allow domains to store the `sortAlphabetically` flag
- expose UI toggle for alphabetical community sorting
- add English translation for the new option

## Testing
- `npm test` *(fails: wtr not found)*
- `npm run lint` *(fails: lit-analyzer not found)*