### PR TITLE
Fix invite activity domain lookup

### DIFF
--- a/server_api/src/controllers/communities.cjs
+++ b/server_api/src/controllers/communities.cjs
@@ -1327,21 +1327,34 @@ router.post(
         },
         function (callback) {
           if (!req.query.addToCommunityDirectly) {
-            models.AcActivity.inviteCreated(
-              {
-                email: req.params.userEmail,
-                user_id: user ? user.id : null,
-                sender_user_id: req.user.id,
-                community_id: req.params.communityId,
-                sender_name: req.user.name,
-                domain_id: req.ypDomain.id,
-                invite_id: invite.id,
-                token: token,
+            models.Community.findOne({
+              where: {
+                id: req.params.communityId,
               },
-              function (error) {
+              attributes: ["id", "domain_id"],
+            })
+              .then(function (community) {
+                const domainId = community ? community.domain_id : req.ypDomain.id;
+
+                models.AcActivity.inviteCreated(
+                  {
+                    email: req.params.userEmail,
+                    user_id: user ? user.id : null,
+                    sender_user_id: req.user.id,
+                    community_id: req.params.communityId,
+                    sender_name: req.user.name,
+                    domain_id: domainId,
+                    invite_id: invite.id,
+                    token: token,
+                  },
+                  function (error) {
+                    callback(error);
+                  }
+                );
+              })
+              .catch(function (error) {
                 callback(error);
-              }
-            );
+              });
           } else {
             callback();
           }

--- a/server_api/src/controllers/groups.cjs
+++ b/server_api/src/controllers/groups.cjs
@@ -1688,21 +1688,43 @@ router.post(
         },
         function (callback) {
           if (!req.query.addToGroupDirectly) {
-            models.AcActivity.inviteCreated(
-              {
-                email: req.params.userEmail,
-                user_id: user ? user.id : null,
-                sender_user_id: req.user.id,
-                sender_name: req.user.name,
-                group_id: req.params.groupId,
-                domain_id: req.ypDomain.id,
-                invite_id: invite.id,
-                token: token,
+            models.Group.findOne({
+              where: {
+                id: req.params.groupId,
               },
-              function (error) {
+              attributes: ["id", "community_id"],
+              include: [
+                {
+                  model: models.Community,
+                  attributes: ["id", "domain_id"],
+                },
+              ],
+            })
+              .then(function (group) {
+                const domainId =
+                  group && group.Community
+                    ? group.Community.domain_id
+                    : req.ypDomain.id;
+
+                models.AcActivity.inviteCreated(
+                  {
+                    email: req.params.userEmail,
+                    user_id: user ? user.id : null,
+                    sender_user_id: req.user.id,
+                    sender_name: req.user.name,
+                    group_id: req.params.groupId,
+                    domain_id: domainId,
+                    invite_id: invite.id,
+                    token: token,
+                  },
+                  function (error) {
+                    callback(error);
+                  }
+                );
+              })
+              .catch(function (error) {
                 callback(error);
-              }
-            );
+              });
           } else {
             callback();
           }


### PR DESCRIPTION
## Summary
- ensure group invite activities load community domain ID first
- ensure community invite activities use community domain ID

## Testing
- `node --check server_api/src/controllers/groups.cjs`
- `node --check server_api/src/controllers/communities.cjs`
