### PR TITLE
Fix first click share dialog issue

### DIFF
--- a/webApps/client/src/common/yp-share-dialog.ts
+++ b/webApps/client/src/common/yp-share-dialog.ts
@@ -50,6 +50,8 @@ export class YpShareDialog extends YpBaseElement {
 
     this.requestUpdate();
 
-    (this.$$('#shareButton') as any/*ShareMenu*/).share();
+    await this.updateComplete;
+
+    (this.$$('#shareButton') as any /*ShareMenu*/).share();
   }
 }


### PR DESCRIPTION
## Summary
- wait for Lit element update completion before opening the share menu

## Testing
- `npm run lint` *(fails: no-invalid-css, no-unknown-property, etc.)*