### PR TITLE
Introduce hashed locales folder

### DIFF
--- a/webApps/client/src/common/test/setup-app.ts
+++ b/webApps/client/src/common/test/setup-app.ts
@@ -6,15 +6,18 @@ import HttpApi from 'i18next-http-backend';
 import { html } from 'lit';
 import fetchMock from 'fetch-mock';
 
+declare let __LOCALES_DIR__: string;
+
 export class YpTestHelpers {
   static async setupApp() {
     window.serverApi = new YpServerApi();
     window.appGlobals = new YpAppGlobals(window.serverApi);
     window.appUser = new YpAppUser(window.serverApi);
+    const localesFolder = typeof __LOCALES_DIR__ !== 'undefined' ? __LOCALES_DIR__ : 'locales';
     await i18next.use(HttpApi).init({
       lng: 'en',
       fallbackLng: 'en',
-      backend: { loadPath: '/locales/{{lng}}/{{ns}}.json' },
+      backend: { loadPath: `/${localesFolder}/{{lng}}/{{ns}}.json` },
     });
 
     window.appGlobals.locale = 'en';

--- a/webApps/client/src/yp-app/YpAppGlobals.ts
+++ b/webApps/client/src/yp-app/YpAppGlobals.ts
@@ -3,6 +3,8 @@ import i18next from "i18next";
 //import moment from 'moment';
 import HttpApi from "i18next-http-backend";
 
+declare let __LOCALES_DIR__: string;
+
 import { YpServerApi } from "../common/YpServerApi.js";
 import { YpNavHelpers } from "../common/YpNavHelpers.js";
 import { YpCodeBase } from "../common/YpCodeBaseclass.js";
@@ -407,11 +409,13 @@ export class YpAppGlobals extends YpCodeBase {
 
     defaultLocale = defaultLocale.replace("-", "_").toLowerCase();
 
+    const localesFolder = typeof __LOCALES_DIR__ !== 'undefined' ? __LOCALES_DIR__ : 'locales';
+
     i18next.use(HttpApi).init(
       {
         lng: defaultLocale,
         fallbackLng: "en",
-        backend: { loadPath: `${loadPathPrefix}/locales/{{lng}}/{{ns}}.json` },
+        backend: { loadPath: `${loadPathPrefix}/${localesFolder}/{{lng}}/{{ns}}.json` },
       },
       () => {
         window.appGlobals.locale = defaultLocale;


### PR DESCRIPTION
## Summary
- compute hash of `locales` content during build
- copy locales to `dist/locales-<hash>`
- inject hashed folder name into code via `__LOCALES_DIR__`
- update translation loader to use the hashed folder

## Testing
- `npm test` *(fails: Did not find any tests to run)*
- `npm run build`