### PR TITLE
Remove unused skip import

### DIFF
--- a/webApps/client/src/yp-app/yp-app.ts
+++ b/webApps/client/src/yp-app/yp-app.ts
@@ -68,7 +68,6 @@ import { YpSnackbar } from "./yp-snackbar.js";
 import { PsAppGlobals } from "../policySynth/PsAppGlobals.js";
 import { PsServerApi } from "../policySynth/PsServerApi.js";
 import { YpTopAppBar } from "./yp-top-app-bar.js";
-import { skip } from "node:test";
 import { YpGroupType } from "../yp-collection/ypGroupType.js";
 import { YpUserEdit } from "../yp-user/yp-user-edit.js";
 


### PR DESCRIPTION
## Summary
- remove unused skip import from node:test

## Testing
- `grep -n "node:test" -n webApps/client/src/yp-app/yp-app.ts`
