### PR TITLE
Add hideDebate group configuration

### DIFF
--- a/server_api/src/controllers/groups.cjs
+++ b/server_api/src/controllers/groups.cjs
@@ -225,6 +225,10 @@ var updateGroupConfigParameters = function (req, group) {
     truthValueFromBody(req.body.disableDebate)
   );
   group.set(
+    "configuration.hideDebate",
+    truthValueFromBody(req.body.hideDebate)
+  );
+  group.set(
     "configuration.locationHidden",
     truthValueFromBody(req.body.locationHidden)
   );

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -269,6 +269,7 @@ interface YpGroupConfiguration extends YpCollectionConfiguration {
   customVoteUpHoverText?: string;
   customVoteDownHoverText?: string;
   hideDebateIcon?: boolean;
+  hideDebate?: boolean;
   originalHideVoteCount?: boolean;
   hideVoteCountUntilVoteCompleted?: boolean;
   endorsementButtons?: string;

--- a/webApps/client/src/yp-post/yp-post-points.ts
+++ b/webApps/client/src/yp-post/yp-post-points.ts
@@ -954,6 +954,9 @@ export class YpPostPoints extends YpBaseElementWithLogin {
   }
 
   override render() {
+    if (this.post?.Group?.configuration?.hideDebate) {
+      return nothing;
+    }
     return html`
       <div class="processBar layout horizontal center-center">
         <md-linear-progress
@@ -1377,6 +1380,15 @@ export class YpPostPoints extends YpBaseElementWithLogin {
       this.post &&
       this.post.Group &&
       this.post.Group.configuration &&
+      this.post.Group.configuration?.hideDebate
+    ) {
+      this.disableDebate = true;
+      return;
+    }
+    if (
+      this.post &&
+      this.post.Group &&
+      this.post.Group.configuration &&
       this.post.Group.configuration?.disableDebate
     ) {
       if (this.isAdmin && this.post.Group.configuration?.allowAdminsToDebate) {
@@ -1390,6 +1402,14 @@ export class YpPostPoints extends YpBaseElementWithLogin {
   }
 
   async _getPoints() {
+    if (
+      this.post &&
+      this.post.Group &&
+      this.post.Group.configuration &&
+      this.post.Group.configuration?.hideDebate
+    ) {
+      return;
+    }
     this.fetchActive = true;
     const pointsWithCount = (await window.serverApi.getPoints(
       this.post.id
@@ -1435,6 +1455,14 @@ export class YpPostPoints extends YpBaseElementWithLogin {
     this.storedDownPointsCount = 0;
 
     if (this.post) {
+      if (
+        this.post.Group &&
+        this.post.Group.configuration &&
+        this.post.Group.configuration?.hideDebate
+      ) {
+        this.disableDebate = true;
+        return;
+      }
       if (
         this.post.Group &&
         this.post.Group.configuration &&


### PR DESCRIPTION
## Summary
- define new `hideDebate` option in `YpGroupConfiguration`
- save `hideDebate` from requests in group controller
- respect `hideDebate` setting in `yp-post-points` so the debate UI is hidden

## Testing
- `npx tsc -p webApps/client/tsconfig.json` *(fails: Cannot find module 'lit', etc.)*
- `npx tsc -p server_api/src/tsconfig.json` *(fails: Cannot find module 'express', etc.)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.