### PR TITLE
Add forceElectronicIds configuration

### DIFF
--- a/server_api/src/controllers/domains.cjs
+++ b/server_api/src/controllers/domains.cjs
@@ -826,6 +826,7 @@ function updateDomainProperties(domain, req) {
   domain.set('configuration.ziggeoApplicationToken', (req.body.ziggeoApplicationToken && req.body.ziggeoApplicationToken !== "") ? req.body.ziggeoApplicationToken : null);
   domain.set('configuration.ga4Tag', (req.body.ga4Tag && req.body.ga4Tag !== "") ? req.body.ga4Tag : null);
   domain.set('configuration.useLoginOnDomainIfNotLoggedIn', truthValueFromBody(req.body.useLoginOnDomainIfNotLoggedIn));
+  domain.set('configuration.forceElectronicIds', truthValueFromBody(req.body.forceElectronicIds));
 
   if (req.body.google_analytics_code && req.body.google_analytics_code !== "") {
     domain.google_analytics_code = req.body.google_analytics_code;

--- a/server_api/src/controllers/users.cjs
+++ b/server_api/src/controllers/users.cjs
@@ -1281,6 +1281,15 @@ const setSAMLSettingsOnUser = (req, user, done) => {
         }
       }
 
+      if (
+        !forceSecureSamlLogin &&
+        req.ypDomain &&
+        req.ypDomain.configuration &&
+        req.ypDomain.configuration.forceElectronicIds
+      ) {
+        forceSecureSamlLogin = true;
+      }
+
       if (user.dataValues) {
         user.dataValues.forceSecureSamlLogin = forceSecureSamlLogin;
         user.dataValues.customSamlDeniedMessage = customSamlDeniedMessage;

--- a/webApps/client/locales/en/translation.json
+++ b/webApps/client/locales/en/translation.json
@@ -775,6 +775,7 @@
   "hidePostFilterAndSearch": "Hide post filter and search",
   "forceSecureSamlLoginInfo": "To access this group you need to login with secure electronic identification to ensure one vote per person. Click below to login.",
   "forceSecureSamlLogin": "Force secure SAML eID login",
+  "forceElectronicIds": "Force electronic ID login",
   "areYouSureYouWantToAnonymizeUser": "Are you sure you want to anonymize your account?",
   "areYouReallySureYouWantToAnonymizeUser": "Are you 100% sure you want to anonymize your account? All your posts, points, comments and endorsements will be anonymized",
   "deleteAccount": "Delete Account",

--- a/webApps/client/src/admin/yp-admin-config-domain.ts
+++ b/webApps/client/src/admin/yp-admin-config-domain.ts
@@ -350,6 +350,10 @@ export class YpAdminConfigDomain extends YpAdminConfigBase {
           type: "checkbox",
         },
         {
+          text: "forceElectronicIds",
+          type: "checkbox",
+        },
+        {
           text: "welcomeHtmlInsteadOfCommunitiesList",
           type: "textarea",
           rows: 5,

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -486,6 +486,7 @@ interface YpDomainConfiguration extends YpCollectionConfiguration {
   onlyAdminsCanCreateCommunities?: boolean;
   directSamlIntegration?: boolean;
   useLoginOnDomainIfNotLoggedIn?: boolean;
+  forceElectronicIds?: boolean;
   disableArrowBasedTopNavigation?: boolean;
   useFixedTopAppBar?: boolean;
   onlyAllowCreateUserOnInvite?: boolean;

--- a/webApps/client/src/yp-collection/yp-domain.ts
+++ b/webApps/client/src/yp-collection/yp-domain.ts
@@ -113,7 +113,10 @@ export class YpDomain extends YpCollection {
     window.appGlobals.setRegistrationQuestionGroup(undefined);
     window.appGlobals.disableFacebookLoginForGroup = false;
     window.appGlobals.externalGoalTriggerGroupId = undefined;
-    window.appGlobals.currentForceSaml = false;
+    window.appGlobals.currentForceSaml =
+      domain && domain.configuration && domain.configuration.forceElectronicIds
+        ? true
+        : false;
     window.appGlobals.currentSamlDeniedMessage = undefined;
     window.appGlobals.currentSamlLoginMessage = undefined;
     window.appGlobals.currentGroup = undefined;


### PR DESCRIPTION
## Summary
- support `forceElectronicIds` in domain configuration
- expose option in admin UI
- update login behaviour when domain forces electronic IDs
- deliver domain rule in user controller
- document string for English locale

## Testing
- `npx tsc -p server_api/src --pretty false`
- `npx tsc -p webApps/client --pretty false`
