### PR TITLE
Add title for community images

### DIFF
--- a/webApps/client/src/admin/yp-admin-communities.ts
+++ b/webApps/client/src/admin/yp-admin-communities.ts
@@ -80,6 +80,7 @@ export class YpAdminCommunities extends YpBaseElementWithLogin {
           class="mainImage"
           sizing="contain"
           .alt="${community.name}"
+          .title="${community.name}"
           .src="${communityImage}"
         ></yp-image>
         <div class="layout vertical">


### PR DESCRIPTION
## Summary
- show community name as tooltip on community images in admin view

## Testing
- `npx tsc -p webApps/client/tsconfig.json`
- `npx tsc -p server_api/src/tsconfig.json`
