### PR TITLE
Add title to admin header image

### DIFF
--- a/webApps/client/src/admin/yp-admin-app.ts
+++ b/webApps/client/src/admin/yp-admin-app.ts
@@ -1240,6 +1240,7 @@ export class YpAdminApp extends YpBaseElement {
               <yp-image
                 class="collectionLogoImage"
                 sizing="contain"
+                .title="${this.collection?.name}"
                 .alt="${this.collection?.name}"
                 .src="${this.collection
                   ? YpCollectionHelpers.logoImagePath(


### PR DESCRIPTION
## Summary
- set `title` on admin page header image for better accessibility

## Testing
- `npx tsc -p webApps/client`
- `npx tsc -p server_api/src`