### PR TITLE
Add title to login domain image

### DIFF
--- a/webApps/client/src/yp-user/yp-login.ts
+++ b/webApps/client/src/yp-user/yp-login.ts
@@ -815,6 +815,7 @@ export class YpLogin extends YpBaseElement {
         ?hidden="${this.assistantMode}"
         class="domainImage"
         .alt="${window.appGlobals.domain?.name}"
+        .title="${window.appGlobals.domain?.name}"
         sizing="cover"
         .src="${YpCollectionHelpers.logoImagePath(
           "domain",


### PR DESCRIPTION
## Summary
- add a title attribute to the domain logo image in `yp-login`

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
