### PR TITLE
Add alt and title metadata to post cover images

### DIFF
--- a/webApps/client/src/yp-post/yp-post-cover-media.ts
+++ b/webApps/client/src/yp-post/yp-post-cover-media.ts
@@ -324,6 +324,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                 ?header-mode="${this.headerMode}"
                 sizing="cover"
                 .alt="${ifDefined(this.altTag || this.post?.name)}"
+                .title="${ifDefined(this.post?.name)}"
                 ?hidden="${this.defaultPostImageEnabled}"
                 class="main-image pointer"
                 src="https://i.imgur.com/sdsFAoT.png"
@@ -334,6 +335,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                     <yp-image
                       ?headerMode="${this.headerMode}"
                       alt="${ifDefined(this.altTag)}"
+                      .title="${ifDefined(this.post?.name)}"
                       sizing="cover"
                       class="main-image pointer"
                       src="${this.activeDefaultImageUrl}"
@@ -376,6 +378,8 @@ export class YpPostCoverMedia extends YpBaseElement {
                 .header-mode="${this.headerMode}"
                 @click="${this._goToPost}"
                 .sizing="${this.sizingMode}"
+                .alt="${ifDefined(this.altTag || this.post?.name)}"
+                .title="${ifDefined(this.post?.name)}"
                 class="main-image pointer"
                 src="${this.postImagePath}"></yp-image>
             `
@@ -408,6 +412,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                         @click="${this._goToPost}"
                         sizing="cover"
                         .alt="${ifDefined(this.altTag || this.post?.name)}"
+                        .title="${ifDefined(this.post?.name)}"
                         class="main-image pointer"
                         src="${this.postVideoPosterPath}"></yp-image>
                     </div>
@@ -463,6 +468,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                       class="main-image pointer"
                       sizing="cover"
                       .alt="${ifDefined(this.altTag || this.post?.name)}"
+                      .title="${ifDefined(this.post?.name)}"
                       src="https://maps.googleapis.com/maps/api/staticmap?center=${this.latitude},${this.longitude}&amp;zoom=${this.zoomLevel}&amp;size=432x243&amp;maptype=hybrid&amp;markers=color:red%7Clabel:%7C${this.latitude},${this.longitude}&amp;key=${this.staticMapsApiKey}"
                       ?hidden="${this.streetViewActivated}"></yp-image>
 
@@ -487,6 +493,7 @@ export class YpPostCoverMedia extends YpBaseElement {
                       ?hidden="${this.mapActivated}"
                       sizing="cover"
                       .alt="${ifDefined(this.altTag || this.post?.name)}"
+                      .title="${ifDefined(this.post?.name)}"
                       src="https://maps.googleapis.com/maps/api/staticmap?center=${this.latitude},${this.longitude}&amp;size=432x243&amp;zoom=${this.zoomLevel}&amp;maptype=${this.mapType}&amp;markers=color:red%7Clabel:%7C${this.latitude},${this.longitude}&amp;key=${this.staticMapsApiKey}"></yp-image>
 
                     ${this.mapActivated


### PR DESCRIPTION
## Summary
- add title attributes alongside alt tags in `yp-post-cover-media`
- include alt & title on main post image

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
