### PR TITLE
Add title to yp-image in post edit

### DIFF
--- a/webApps/client/src/yp-post/yp-post-edit.ts
+++ b/webApps/client/src/yp-post/yp-post-edit.ts
@@ -749,6 +749,7 @@ export class YpPostEdit extends YpEditBase {
             sizing="cover"
             .skipCloudFlare="${true}"
             .alt="${ifDefined(this.post?.name)}"
+            .title="${ifDefined(this.post?.name)}"
             src="${this.imagePreviewUrl}"
           ></yp-image>
         </div>
@@ -763,6 +764,7 @@ export class YpPostEdit extends YpEditBase {
             class="image"
             sizing="cover"
             .alt="${ifDefined(this.post?.name)}"
+            .title="${ifDefined(this.post?.name)}"
             src="${YpMediaHelpers.getImageFormatUrl(
               this.post?.PostHeaderImages
             )}"
@@ -775,6 +777,7 @@ export class YpPostEdit extends YpEditBase {
           class="image"
           sizing="contain"
           .alt="${ifDefined(this.post?.name)}"
+          .title="${ifDefined(this.post?.name)}"
           src="https://yrpri-eu-direct-assets.s3.eu-west-1.amazonaws.com/ypPlaceHolder2.jpg"
         ></yp-image>
       `;


### PR DESCRIPTION
## Summary
- keep accessibility info by adding `.title` to all `<yp-image>` components in `yp-post-edit`

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
