### PR TITLE
Fix yp-post image title

### DIFF
--- a/webApps/client/src/yp-post/yp-post-user-image-card.ts
+++ b/webApps/client/src/yp-post/yp-post-user-image-card.ts
@@ -103,6 +103,7 @@ export class YpPostUserImageCard extends YpBaseElement {
         class="material layout vertical shadow-elevation-2dp shadow-transition">
         <yp-image
           .alt="${this.image.description}"
+          .title="${this.image.description}"
           sizing="cover"
           src="${this.imageUrl}"></yp-image>
         <div class="description">


### PR DESCRIPTION
## Summary
- display alt text as title on yp-image in `yp-post-user-image-card`

## Testing
- `tsc -p server_api/src/tsconfig.json --noEmit -v`
- `tsc -p webApps/client/tsconfig.json --noEmit -v`
