### PR TITLE
Add title attribute to news story thumbnail

### DIFF
--- a/webApps/client/src/yp-point/yp-point-news-story-embed.ts
+++ b/webApps/client/src/yp-point/yp-point-news-story-embed.ts
@@ -69,6 +69,7 @@ export class YpPointNewsStoryEmbed extends YpBaseElement {
                     sizing="contain"
                     src="${this.embedData.thumbnail_url}"
                     .alt="${this.embedData.title}"
+                    .title="${this.embedData.title}"
                     ?hidden="${this.embedData.html != null}"></yp-image>
                   <div id="embedHtml" ?hidden="${!this.embedData.html}">
                     <div .inner-h-t-m-l="${this.embedData}"></div>


### PR DESCRIPTION
## Summary
- display embed title as tooltip on news story thumbnails

## Testing
- `npx tsc -p webApps/client`
- `npx tsc -p server_api/src`
