### PR TITLE
Add title property to AoiSurveyIntro logo image

### DIFF
--- a/webApps/client/src/allOurIdeas/survey/aoi-survey-intro.ts
+++ b/webApps/client/src/allOurIdeas/survey/aoi-survey-intro.ts
@@ -237,6 +237,7 @@ export class AoiSurveyIntro extends YpBaseElement {
             class="column image"
             sizing="contain"
             .alt="${this.group.name}"
+            .title="${this.group.name}"
             src="${YpMediaHelpers.getImageFormatUrl(
               this.group.GroupLogoImages
             )}"


### PR DESCRIPTION
## Summary
- assign `.title` to the group logo `<yp-image>` in `aoi-survey-intro`

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
