### PR TITLE
Add domain option for eID user creation

### DIFF
--- a/server_api/src/controllers/domains.cjs
+++ b/server_api/src/controllers/domains.cjs
@@ -827,6 +827,10 @@ function updateDomainProperties(domain, req) {
   domain.set('configuration.ga4Tag', (req.body.ga4Tag && req.body.ga4Tag !== "") ? req.body.ga4Tag : null);
   domain.set('configuration.useLoginOnDomainIfNotLoggedIn', truthValueFromBody(req.body.useLoginOnDomainIfNotLoggedIn));
   domain.set('configuration.forceElectronicIds', truthValueFromBody(req.body.forceElectronicIds));
+  domain.set(
+    'configuration.doNotCreateElectronicIdUsersAutomatically',
+    truthValueFromBody(req.body.doNotCreateElectronicIdUsersAutomatically)
+  );
 
   if (req.body.google_analytics_code && req.body.google_analytics_code !== "") {
     domain.google_analytics_code = req.body.google_analytics_code;

--- a/server_api/src/models/user.cjs
+++ b/server_api/src/models/user.cjs
@@ -125,7 +125,7 @@ module.exports = (sequelize, DataTypes) => {
   User.serializeSamlUser = (profile, req, callback) => {
     log.info("Serialize SAML user", { context: 'serializeSamlUser', profile: profile });
     if (profile.UserSSN) {
-      sequelize.models.User.serializeIslandIsSamlUser(profile, callback);
+      sequelize.models.User.serializeIslandIsSamlUser(profile, req, callback);
     } else if (profile["urn:mynj:userCode"] || profile.issuer === 'https://my.state.nj.us/idp/shibboleth') {
       sequelize.models.User.serializeMyNJSamlUser(profile, req, callback);
     } else {
@@ -194,6 +194,13 @@ module.exports = (sequelize, DataTypes) => {
       },
       (seriesCallback) => {
         if (!user) {
+          if (
+            req.ypDomain.configuration &&
+            req.ypDomain.configuration.doNotCreateElectronicIdUsersAutomatically
+          ) {
+            seriesCallback("customError");
+            return;
+          }
           sequelize.models.User.create(
             {
               ssn: profile["urn:mynj:userCode"],
@@ -232,7 +239,7 @@ module.exports = (sequelize, DataTypes) => {
     });
   };
 
-  User.serializeIslandIsSamlUser = (profile, callback) => {
+  User.serializeIslandIsSamlUser = (profile, req, callback) => {
     log.info("User Serialized In Serialize IslandIs SAML User", { context: 'serializeSamlUser', profile: profile });
     let user;
     async.series([
@@ -256,6 +263,13 @@ module.exports = (sequelize, DataTypes) => {
       },
       (seriesCallback) => {
         if (!user) {
+          if (
+            req.ypDomain.configuration &&
+            req.ypDomain.configuration.doNotCreateElectronicIdUsersAutomatically
+          ) {
+            seriesCallback("customError");
+            return;
+          }
           sequelize.models.User.create(
             {
               ssn: profile.UserSSN,
@@ -311,6 +325,13 @@ module.exports = (sequelize, DataTypes) => {
       },
       (seriesCallback) => {
         if (!user) {
+          if (
+            req.ypDomain.configuration &&
+            req.ypDomain.configuration.doNotCreateElectronicIdUsersAutomatically
+          ) {
+            seriesCallback("customError");
+            return;
+          }
           sequelize.models.User.create({
             ssn: profile.nationalRegisterId,
             name: profile.name,

--- a/webApps/client/locales/en/translation.json
+++ b/webApps/client/locales/en/translation.json
@@ -776,6 +776,7 @@
   "forceSecureSamlLoginInfo": "To access this group you need to login with secure electronic identification to ensure one vote per person. Click below to login.",
   "forceSecureSamlLogin": "Force secure SAML eID login",
   "forceElectronicIds": "Force electronic ID login",
+  "doNotCreateElectronicIdUsersAutomatically": "Do not automatically create electronic ID users",
   "areYouSureYouWantToAnonymizeUser": "Are you sure you want to anonymize your account?",
   "areYouReallySureYouWantToAnonymizeUser": "Are you 100% sure you want to anonymize your account? All your posts, points, comments and endorsements will be anonymized",
   "deleteAccount": "Delete Account",

--- a/webApps/client/src/admin/yp-admin-config-domain.ts
+++ b/webApps/client/src/admin/yp-admin-config-domain.ts
@@ -354,6 +354,10 @@ export class YpAdminConfigDomain extends YpAdminConfigBase {
           type: "checkbox",
         },
         {
+          text: "doNotCreateElectronicIdUsersAutomatically",
+          type: "checkbox",
+        },
+        {
           text: "welcomeHtmlInsteadOfCommunitiesList",
           type: "textarea",
           rows: 5,

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -487,6 +487,7 @@ interface YpDomainConfiguration extends YpCollectionConfiguration {
   directSamlIntegration?: boolean;
   useLoginOnDomainIfNotLoggedIn?: boolean;
   forceElectronicIds?: boolean;
+  doNotCreateElectronicIdUsersAutomatically?: boolean;
   disableArrowBasedTopNavigation?: boolean;
   useFixedTopAppBar?: boolean;
   onlyAllowCreateUserOnInvite?: boolean;


### PR DESCRIPTION
## Summary
- add `doNotCreateElectronicIdUsersAutomatically` flag to domain configuration
- expose new option in admin UI and type definitions
- prevent automatic user creation for SAML and OIDC when the flag is set
- document translation for the new option

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
