### PR TITLE
Add customer AI token markup setting

### DIFF
--- a/server_api/src/controllers/domains.cjs
+++ b/server_api/src/controllers/domains.cjs
@@ -892,6 +892,13 @@ function updateDomainProperties(domain, req) {
   domain.set('configuration.useFixedTopAppBar', truthValueFromBody(req.body.useFixedTopAppBar));
   domain.set('configuration.disableArrowBasedTopNavigation', truthValueFromBody(req.body.disableArrowBasedTopNavigation));
 
+  domain.set(
+    'configuration.customerAiTokenMarkupPercent',
+    req.body.customerAiTokenMarkupPercent && req.body.customerAiTokenMarkupPercent !== ''
+      ? parseInt(req.body.customerAiTokenMarkupPercent)
+      : null
+  );
+
   domain.set('configuration.onlyAllowCreateUserOnInvite', truthValueFromBody(req.body.onlyAllowCreateUserOnInvite));
 
   domain.name = req.body.name;

--- a/server_api/src/server.d.ts
+++ b/server_api/src/server.d.ts
@@ -37,6 +37,7 @@ interface DomainClass extends DbData {
     ltp?: {
       crt?: LtpCurrentRealityTreeData
     }
+    customerAiTokenMarkupPercent?: number;
   };
 }
 

--- a/webApps/client/src/admin/yp-admin-config-domain.ts
+++ b/webApps/client/src/admin/yp-admin-config-domain.ts
@@ -171,6 +171,7 @@ export class YpAdminConfigDomain extends YpAdminConfigBase {
           useLoginOnDomainIfNotLoggedIn: true,
           disableArrowBasedTopNavigation: true,
           useFixedTopAppBar: true,
+          customerAiTokenMarkupPercent: 0,
         } as YpDomainConfiguration,
       } as YpDomainData;
 
@@ -344,6 +345,15 @@ export class YpAdminConfigDomain extends YpAdminConfigBase {
         {
           text: "disableArrowBasedTopNavigation",
           type: "checkbox",
+        },
+        {
+          text: "customerAiTokenMarkupPercent",
+          type: "textfield",
+          maxLength: 4,
+          value:
+            (this.collection?.configuration as YpDomainConfiguration)
+              .customerAiTokenMarkupPercent,
+          translationToken: "customerAiTokenMarkupPercent",
         },
         {
           text: "useLoginOnDomainIfNotLoggedIn",

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -491,6 +491,7 @@ interface YpDomainConfiguration extends YpCollectionConfiguration {
   disableArrowBasedTopNavigation?: boolean;
   useFixedTopAppBar?: boolean;
   onlyAllowCreateUserOnInvite?: boolean;
+  customerAiTokenMarkupPercent?: number;
   hideDomainNews?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- extend Domain configuration types with `customerAiTokenMarkupPercent`
- handle new option in domain controller
- expose setting on domain admin UI

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client`