### PR TITLE
Add alt text for operations header image

### DIFF
--- a/webApps/client/src/policySynth/ps-operations-view.ts
+++ b/webApps/client/src/policySynth/ps-operations-view.ts
@@ -834,6 +834,7 @@ export class PsOperationsView extends PsBaseWithRunningAgentObserver {
             0
           )}"
           class="agentHeaderImage"
+          alt="${this.group.name}"
         />
         <div class="layout vertical agentHeaderText">${this.group.name}</div>
       </div>


### PR DESCRIPTION
## Summary
- add descriptive `alt` attribute to the group logo in `ps-operations-view`

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
