### PR TITLE
Add alt text for video preview images

### DIFF
--- a/webApps/client/src/yp-file-upload/yp-set-video-cover.ts
+++ b/webApps/client/src/yp-file-upload/yp-set-video-cover.ts
@@ -103,6 +103,7 @@ export class YpSetVideoCover extends YpBaseElement {
                     @click="${this._selectVideoCover}"
                     sizing="cover"
                     class="previewFrame"
+                    alt="Preview frame ${index + 1}"
                     src="${image}" />
                 `
               )}


### PR DESCRIPTION
## Summary
- provide alt text for each preview frame in video cover picker

## Testing
- `time npx tsc -p server_api/src/tsconfig.json --noEmit`
- `time npx tsc -p webApps/client/tsconfig.json --noEmit`
