### PR TITLE
Add alt attribute in AOI survey results

### DIFF
--- a/webApps/client/src/allOurIdeas/survey/aoi-survey-results.ts
+++ b/webApps/client/src/allOurIdeas/survey/aoi-survey-results.ts
@@ -304,6 +304,7 @@ export class AoiSurveyResuls extends YpBaseElement {
                 class="answerImage"
                 ?hidden="${result.data.imageUrl == undefined}"
                 src="${result.data.imageUrl!}"
+                alt="${result.data.content}"
               />
             </div>
             <div


### PR DESCRIPTION
## Summary
- give `<img>` an alt attribute in AOI survey results

## Testing
- `npx tsc -p webApps/client/tsconfig.json`
- `npx tsc -p server_api/src/tsconfig.json`
