### PR TITLE
Add alt text to promotion app logo

### DIFF
--- a/webApps/client/src/analytics-and-promotion/yp-promotion-app.ts
+++ b/webApps/client/src/analytics-and-promotion/yp-promotion-app.ts
@@ -266,6 +266,7 @@ export class YpPromotionApp extends YpBaseElementWithLogin {
                       this.collection!
                     )
                   )}"
+                  alt="${this.collection?.name || 'Collection logo'}"
                 />
               </div>
               <div></div>


### PR DESCRIPTION
## Summary
- add `alt` attribute to the logo image in `renderTopBar`

## Testing
- `npx tsc -p webApps/client/tsconfig.json`
- `npx tsc -p server_api/src/tsconfig.json`
