### PR TITLE
Add alt to org grid images

### DIFF
--- a/webApps/client/src/admin/yp-organization-grid.ts
+++ b/webApps/client/src/admin/yp-organization-grid.ts
@@ -123,6 +123,7 @@ export class YpOrganizationGrid extends YpBaseElement {
               <div class="pageItem">
                 <img
                   src="${this._organizationImageUrl(organization)}"
+                  alt="${organization.name}"
                   class="orgLogo"
                 />
               </div>


### PR DESCRIPTION
## Summary
- add alt text for organization logos in admin grid

## Testing
- `npx tsc -p webApps/client/tsconfig.json`
- `npx tsc -p server_api/src/tsconfig.json`
