### PR TITLE
Add alt attribute to operations manager header image

### DIFF
--- a/webApps/client/src/policySynth/ps-operations-manager.ts
+++ b/webApps/client/src/policySynth/ps-operations-manager.ts
@@ -563,6 +563,7 @@ export class PsOperationsManager extends PsBaseWithRunningAgentObserver {
             0
           )}"
           class="agentHeaderImage"
+          alt="${this.group.name}"
         />
         <div class="layout vertical agentHeaderText">
           <div class="workflowName">${this.t("workflow")}</div>


### PR DESCRIPTION
## Summary
- provide alt text for the group image in `ps-operations-manager`

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
