### PR TITLE
Fix alt text in edit node dialog

### DIFF
--- a/webApps/client/src/policySynth/ps-edit-node-dialog.ts
+++ b/webApps/client/src/policySynth/ps-edit-node-dialog.ts
@@ -136,6 +136,7 @@ export class PsEditNodeDialog extends YpBaseElement {
         <div>
           <img
             src="${this.nodeToEditInfo.Class.configuration.imageUrl}"
+            alt="${this.nodeToEditInfo.Class.name}"
             class="nodeEditHeadlineImage"
           />
         </div>


### PR DESCRIPTION
## Summary
- add alt attribute to node edit dialog image

## Testing
- `npx tsc -p webApps/client`
- `npx tsc -p server_api/src`
