### PR TITLE
Add alt text to connector images

### DIFF
--- a/webApps/client/src/policySynth/ps-connector-node.ts
+++ b/webApps/client/src/policySynth/ps-connector-node.ts
@@ -160,6 +160,7 @@ export class PsAgentConnector extends PsOperationsBaseNode {
           class="image"
           ?has-static-theme=${this.hasStaticTheme}
           src="${this.connector.Class?.configuration.imageUrl}"
+          alt="${this.connector.Class?.name}"
         />
       </div>
     `;


### PR DESCRIPTION
## Summary
- add missing alt attribute for connector images

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
