### PR TITLE
Fix OIDC redirect option

### DIFF
--- a/server_api/src/controllers/users.cjs
+++ b/server_api/src/controllers/users.cjs
@@ -2258,7 +2258,11 @@ router.get('/auth/oidc/callback', function(req, res) {
       log.error("Error from OIDC login", { err: error });
       res.sendStatus(500);
     } else {
-      res.render('samlLoginComplete', {});
+      if (process.env.REDIRECT_TO_ROOT_AFTER_OIDC) {
+        res.redirect('/');
+      } else {
+        res.render('samlLoginComplete', {});
+      }
     }
   })
 });


### PR DESCRIPTION
## Summary
- allow redirect to `/` after OIDC callback if `REDIRECT_TO_ROOT_AFTER_OIDC` environment variable is set

## Testing
- `npx tsc -p server_api/src`
- `npx tsc -p webApps/client`