### PR TITLE
Add env redirect after Audkenni login

### DIFF
--- a/server_api/src/controllers/users.cjs
+++ b/server_api/src/controllers/users.cjs
@@ -2316,7 +2316,9 @@ router.get('/auth/audkenni/callback', async function(req, res) {
         res.sendStatus(500);
       }
     } else {
-      if (process.env.REDIRECT_TO_ROOT_AFTER_OIDC) {
+      if (process.env.REDIRECT_AFTER_AUDKENNI_URL) {
+        res.redirect(process.env.REDIRECT_AFTER_AUDKENNI_URL);
+      } else if (process.env.REDIRECT_TO_ROOT_AFTER_OIDC) {
         res.redirect('/');
       } else {
         res.render('samlLoginComplete', {});


### PR DESCRIPTION
## Summary
- add REDIRECT_AFTER_AUDKENNI_URL env var to override redirect after Audkenni login

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`
