### PR TITLE
Add Audkenni REST login component

### DIFF
--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -601,6 +601,7 @@ interface YpDomainData extends YpCollectionData {
   Communities: Array<YpCommunityData>;
   facebookLoginProvided?: boolean;
   samlLoginProvided?: boolean;
+  audkenniRestLoginProvided?: boolean;
   loginCallbackCustomHostName?: string;
   hasLlm?: boolean;
   access?: number;

--- a/webApps/client/src/yp-user/yp-audkenni-login.ts
+++ b/webApps/client/src/yp-user/yp-audkenni-login.ts
@@ -1,0 +1,137 @@
+import { html, css, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { YpBaseElement } from '../common/yp-base-element.js';
+
+import '@material/web/textfield/outlined-text-field.js';
+import '@material/web/button/filled-button.js';
+import '@material/web/progress/circular-progress.js';
+import '@material/web/radio/radio.js';
+
+@customElement('yp-audkenni-login')
+export class YpAudkenniLogin extends YpBaseElement {
+  @property({ type: String })
+  phone = '';
+
+  @property({ type: String })
+  authenticator: 'sim' | 'card' = 'sim';
+
+  @property({ type: Boolean })
+  polling = false;
+
+  @property({ type: String })
+  pollId: string | undefined;
+
+  static override get styles() {
+    return [
+      super.styles,
+      css`
+        .loginField {
+          margin-bottom: 8px;
+          width: 100%;
+        }
+        .options {
+          margin-bottom: 8px;
+        }
+        .status {
+          margin-top: 8px;
+        }
+      `,
+    ];
+  }
+
+  override render() {
+    return html`
+      <div>
+        <md-outlined-text-field
+          class="loginField"
+          .value=${this.phone}
+          @input=${(e: Event) =>
+            (this.phone = (e.target as HTMLInputElement).value)}
+          label="${this.t('user.phoneNumber') || 'Phone number'}"
+        ></md-outlined-text-field>
+
+        <div class="options layout horizontal center-center">
+          <label class="layout horizontal center-center">
+            <md-radio
+              name="auth"
+              value="sim"
+              ?checked=${this.authenticator === 'sim'}
+              @change=${() => (this.authenticator = 'sim')}
+            ></md-radio>
+            <span>SIM</span>
+          </label>
+          <label class="layout horizontal center-center">
+            <md-radio
+              name="auth"
+              value="card"
+              ?checked=${this.authenticator === 'card'}
+              @change=${() => (this.authenticator = 'card')}
+            ></md-radio>
+            <span>Card</span>
+          </label>
+        </div>
+
+        <md-filled-button
+          @click=${this.startLogin}
+          ?disabled=${this.polling}
+          >${this.t('login') || 'Login'}</md-filled-button
+        >
+
+        <div class="status" ?hidden=${!this.polling}>
+          <md-circular-progress indeterminate></md-circular-progress>
+          <span>${this.t('user.waitingForConfirmation') || 'Waiting for confirmation...'}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  async startLogin() {
+    if (!this.phone) {
+      this.fire('yp-error', this.t('user.completeForm'));
+      return;
+    }
+    this.polling = true;
+    const response = await fetch('/api/users/auth/audkenni-rest/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phone: this.phone, authenticator: this.authenticator }),
+    });
+    if (response.ok) {
+      const data = await response.json();
+      this.pollId = data.id || data.pollId;
+      this._poll();
+    } else {
+      this.polling = false;
+      this.fire('yp-error', this.t('user.loginNotAuthorized'));
+    }
+  }
+
+  async _poll() {
+    if (!this.pollId) {
+      this.polling = false;
+      return;
+    }
+    const response = await fetch(
+      `/api/users/auth/audkenni-rest/poll/${this.pollId}`
+    );
+    if (response.ok) {
+      const data = await response.json();
+      if (data.pending) {
+        setTimeout(() => this._poll(), 2000);
+      } else if (data.user) {
+        this.polling = false;
+        this.dispatchEvent(
+          new CustomEvent('login-completed', {
+            detail: data.user,
+            bubbles: true,
+            composed: true,
+          })
+        );
+      } else {
+        setTimeout(() => this._poll(), 2000);
+      }
+    } else {
+      this.polling = false;
+    }
+  }
+}

--- a/webApps/client/src/yp-user/yp-login.ts
+++ b/webApps/client/src/yp-user/yp-login.ts
@@ -3,6 +3,7 @@ import { customElement, property } from "lit/decorators.js";
 
 import "./yp-registration-questions.js";
 import "./yp-forgot-password.js";
+import "./yp-audkenni-login.js";
 
 import { YpBaseElement } from "../common/yp-base-element.js";
 import { YpNavHelpers } from "../common/YpNavHelpers.js";
@@ -735,6 +736,12 @@ export class YpLogin extends YpBaseElement {
             : nothing}
           ${this.hasSamlLogin ? this.renderSamlLogin() : nothing}
         </div>
+        ${this.hasAudkenniRestLogin
+          ? html`<yp-audkenni-login
+              @login-completed="${(e: CustomEvent) =>
+                this._loginCompleted(e.detail)}"
+            ></yp-audkenni-login>`
+          : nothing}
       </div>
     </div>`;
   }
@@ -1437,6 +1444,7 @@ export class YpLogin extends YpBaseElement {
       this.domain &&
       ((this.hasFacebookLogin && !this.disableFacebookLoginForGroup) ||
         this.hasSamlLogin ||
+        this.hasAudkenniRestLogin ||
         this.hasAnonymousLogin ||
         this.hasOneTimeLoginWithName)
     );
@@ -1461,6 +1469,15 @@ export class YpLogin extends YpBaseElement {
   get hasSamlLogin() {
     if (this.domain) {
       return this.domain.samlLoginProvided;
+    } else {
+      return false;
+    }
+  }
+
+  get hasAudkenniRestLogin() {
+    if (this.domain) {
+      // @ts-ignore - older domains might not have this field
+      return (this.domain as any).audkenniRestLoginProvided === true;
     } else {
       return false;
     }


### PR DESCRIPTION
## Summary
- support Audkenni REST login by adding new `<yp-audkenni-login>` component
- expose new domain flag `audkenniRestLoginProvided`
- integrate the component in the login dialog when enabled

## Testing
- `npx tsc -p webApps/client`
- `npx tsc -p server_api/src`

------
https://chatgpt.com/codex/tasks/task_e_683a4a9237d4832e8d538c8096e118e9