### PR TITLE
Improve Audkenni REST auth flow

### DIFF
--- a/server_api/src/services/auth/audkenniRestService.ts
+++ b/server_api/src/services/auth/audkenniRestService.ts
@@ -32,11 +32,13 @@ export default class AudkenniRestService {
 
   async poll(
     authId: string,
+    callbacks?: any[],
     interval = 2000,
     maxAttempts = 30
   ): Promise<AudkenniAuthResponse> {
     for (let i = 0; i < maxAttempts; i++) {
-      const { data } = await this.client.post(this.endpoint, { authId });
+      const payload = callbacks ? { authId, callbacks } : { authId };
+      const { data } = await this.client.post(this.endpoint, payload);
       if (data.tokenId) {
         return data;
       }


### PR DESCRIPTION
## Summary
- augment AudkenniRestService polling to optionally send callbacks
- hook phone and authenticator into Audkenni start step
- allow polling via `GET /auth/audkenni-rest/poll/:id`

## Testing
- `npx tsc -p server_api/src`
- `npx tsc -p webApps/client`

------
https://chatgpt.com/codex/tasks/task_e_683a4fa2fec0832e8ca3780de35a59fa