### PR TITLE
Add authenticate method for Audkenni REST service

### DIFF
--- a/server_api/src/services/auth/audkenniRestService.ts
+++ b/server_api/src/services/auth/audkenniRestService.ts
@@ -24,6 +24,31 @@ export default class AudkenniRestService {
     return data;
   }
 
+  async authenticate(
+    phone: string,
+    authenticator: 'sim' | 'app'
+  ): Promise<AudkenniAuthResponse> {
+    const startData = await this.start();
+
+    if (!startData.authId || !startData.callbacks) {
+      throw new Error('Invalid start response');
+    }
+
+    const callbacks = (startData.callbacks || []).map((cb: any) => {
+      if (cb.type === 'NameCallback') {
+        cb.input[0].value = phone;
+      } else if (cb.type === 'ChoiceCallback') {
+        const choices = cb.output?.find((o: any) => o.name === 'choices')?.value || [];
+        const idx = choices.findIndex((c: string) => c.toLowerCase().includes(authenticator));
+        cb.input[0].value = idx >= 0 ? idx : 0;
+      }
+      return cb;
+    });
+
+    const cont = await this.continue(startData.authId, callbacks);
+    return this.poll(cont.authId || startData.authId, cont.callbacks);
+  }
+
   async continue(authId: string, callbacks: any[]): Promise<AudkenniAuthResponse> {
     const payload = { authId, callbacks };
     const { data } = await this.client.post(this.endpoint, payload);


### PR DESCRIPTION
## Summary
- add an `authenticate` helper for Audkenni REST flow

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_683a56557600832ea78883da0f208260