### PR TITLE
Add gallery mode for posts

### DIFF
--- a/webApps/client/src/yp-post/yp-post-list-gallery-item.ts
+++ b/webApps/client/src/yp-post/yp-post-list-gallery-item.ts
@@ -1,0 +1,269 @@
+import { html, css, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import { YpBaseElement } from '../common/yp-base-element.js';
+import './yp-post-cover-media.js';
+import './yp-post-actions.js';
+import '../yp-magic-text/yp-magic-text.js';
+import '@material/web/iconbutton/icon-button.js';
+
+import { YpPostCoverMedia } from './yp-post-cover-media.js';
+
+@customElement('yp-post-list-gallery-item')
+export class YpPostListGalleryItem extends YpBaseElement {
+  @property({ type: Object })
+  post!: YpPostData;
+
+  @property({ type: Boolean, attribute: 'description-open' })
+  descriptionOpen = false;
+
+  @property({ type: Boolean })
+  mini = false;
+
+  @property({ type: Boolean })
+  isAudioCover = false;
+
+  static override get styles() {
+    return [
+      super.styles,
+      css`
+        .mainContainer {
+          margin: 32px;
+          margin-top: 48px;
+          margin-bottom: 16px;
+        }
+
+        .authorName,
+        .artName {
+          font-size: 26px;
+          line-height: 1.4;
+          min-width: 350px;
+        }
+
+        .authorName {
+          font-weight: bold;
+          padding-top: 8px;
+          width: 100%;
+        }
+
+        .artName {
+          padding-top: 0;
+        }
+
+        .description {
+          font-size: 20px;
+          line-height: 1.4;
+          text-align: right;
+          margin-bottom: 8px;
+        }
+
+        .descriptionText {
+          text-align: justify;
+          margin-bottom: 8px;
+          margin-top: 8px;
+        }
+
+        .image {
+          margin-bottom: 8px;
+        }
+
+        .postActions {
+          height: 30px;
+          margin-left: -16px;
+        }
+
+        .mainDataContainer {
+          max-width: 600px;
+          width: 600px;
+          border-top: 2px solid #000;
+        }
+
+        md-icon-button.openCloseButton {
+          --md-icon-button-icon-size: 48px;
+          width: 64px;
+          height: 64px;
+          padding-left: 0;
+          margin-left: 0;
+          align-self: flex-end;
+          justify-content: flex-end;
+          margin-right: -24px;
+          color: #000;
+        }
+
+        @media (max-width: 800px) {
+          .authorName,
+          .artName {
+            font-size: 26px;
+            min-width: 100%;
+            color: #000;
+          }
+
+          .image {
+            margin-bottom: 8px;
+          }
+
+          .mainDataContainer {
+            max-width: 100%;
+            width: 100%;
+          }
+        }
+
+        .shareIcon {
+          text-align: right;
+          width: 48px;
+          height: 48px;
+        }
+
+        .shareText {
+          font-size: 16px;
+          color: #656565;
+          margin-right: 5px;
+        }
+      `,
+    ];
+  }
+
+  renderShare() {
+    return html`
+      <div class="share" ?hidden="${this.post.Group.configuration?.hideSharing}">
+        <md-icon-button
+          class="shareIcon"
+          .label="${this.t('share')}"
+          @click="${this._shareTap}"
+        >
+          <md-icon>share</md-icon>
+        </md-icon-button>
+        <div class="shareText">${this.t('share')}</div>
+      </div>
+    `;
+  }
+
+  render() {
+    return html`
+      <div class="layout vertical mainContainer">
+        <div class="layout vertical center-center">
+          <yp-post-cover-media
+            class="image"
+            .post="${this.post}"
+            sizingMode="cover"
+          ></yp-post-cover-media>
+          <div class="layout vertical mainDataContainer">
+            <div class="layout horizontal">
+              <div class="layout vertical">
+                <div class="authorName">${this.post.description}</div>
+                <div class="artName">${this.post.name}</div>
+                <yp-post-actions
+                  class="postActions"
+                  .post="${this.post}"
+                  larger-icons
+                  forceHideDebate
+                ></yp-post-actions>
+              </div>
+              <div class="flex"></div>
+              <div class="layout vertical">
+                ${!this.descriptionOpen
+                  ? html`
+                      <a
+                        href="${ifDefined(this._getPostLink(this.post))}"
+                        id="mainA"
+                        @click="${this._savePostToBackCache}"
+                      >
+                        <md-icon-button class="openCloseButton"
+                          ><md-icon>keyboard-arrow-right</md-icon></md-icon-button
+                        >
+                      </a>
+                    `
+                  : nothing}
+              </div>
+            </div>
+            ${this.descriptionOpen
+              ? html`
+                  ${this.renderShare()}
+                  <div class="description">
+                    ${this.post.public_data?.galleryMetaData?.Upphafsar}
+                  </div>
+                  <div
+                    class="description"
+                    ?hidden="${!this.post.public_data?.galleryMetaData?.Haed}"
+                  >
+                    ${this.post.public_data?.galleryMetaData?.Haed} x
+                    ${this.post.public_data?.galleryMetaData?.Breidd}cm
+                  </div>
+                  <div
+                    class="description descriptionText"
+                    ?hidden="${!this.post.public_data?.galleryMetaData?.texti_um_verk_fyrir_vef}"
+                  >
+                    ${this.post.public_data?.galleryMetaData?.texti_um_verk_fyrir_vef}
+                  </div>
+                `
+              : nothing}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  _savePostToBackCache() {
+    if (this.post) {
+      window.appGlobals.cache.cachedPostItem = this.post;
+    }
+  }
+
+  _getPostLink(post: YpPostData) {
+    if (post) {
+      if (
+        post.Group.configuration &&
+        post.Group.configuration.disablePostPageLink
+      ) {
+        return '#';
+      } else if (
+        post.Group.configuration &&
+        post.Group.configuration.resourceLibraryLinkMode
+      ) {
+        return post.description.trim();
+      } else {
+        return '/post/' + post.id;
+      }
+    } else {
+      console.warn('Trying to get empty post link');
+      return '#';
+    }
+  }
+
+  _sharedContent(event: CustomEvent) {
+    const shareData = event.detail;
+    window.appGlobals.activity(
+      'postShared',
+      shareData.social,
+      this.post ? this.post.id : -1
+    );
+  }
+
+  get _fullPostUrl() {
+    return encodeURIComponent(
+      'https://' + window.location.host + '/post/' + this.post.id
+    );
+  }
+
+  _shareTap(event: CustomEvent) {
+    window.appGlobals.activity(
+      'postShareCardOpen',
+      event.detail.brand,
+      this.post ? this.post.id : -1
+    );
+
+    window.appDialogs.getDialogAsync(
+      'shareDialog',
+      (dialog: YpShareDialogData) => {
+        dialog.open(
+          this._fullPostUrl,
+          this.post.name,
+          (this.$$('yp-post-cover-media') as YpPostCoverMedia).anyImagePath || '',
+          this._sharedContent
+        );
+      }
+    );
+  }
+}
+

--- a/webApps/client/src/yp-post/yp-post.ts
+++ b/webApps/client/src/yp-post/yp-post.ts
@@ -23,6 +23,7 @@ import { YpNavHelpers } from "../common/YpNavHelpers.js";
 import { YpPostCard } from "./yp-post-card.js";
 import { ShadowStyles } from "../common/ShadowStyles.js";
 import "./yp-post-header.js";
+import "./yp-post-list-gallery-item.js";
 import "./yp-post-points.js";
 import "./yp-post-user-images.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -44,6 +45,9 @@ export const PostTabTypes: Record<string, number> = {
 export class YpPost extends YpCollection {
   @property({ type: Boolean })
   isAdmin = false;
+
+  @property({ type: Boolean })
+  isGalleryMode = false;
 
   @property({ type: Boolean })
   disableNewPosts = false;
@@ -350,6 +354,15 @@ export class YpPost extends YpCollection {
     `;
   }
 
+  renderGalleryHeader() {
+    return html`
+      <yp-post-list-gallery-item
+        description-open
+        .post="${this.post!}"
+      ></yp-post-list-gallery-item>
+    `;
+  }
+
   renderPostTabs() {
     if (this.post && !this.post.Group.configuration?.hideAllTabs) {
       return html`
@@ -511,7 +524,10 @@ export class YpPost extends YpCollection {
         <div ?for-agent-bundle="${this.forAgentBundle}" class="layout vertical center-center outerFrameContainer">
           <div class="frameContainer">
             <div class="layout vertical">
-              ${this.renderPostStaticHeader()} ${this.renderPostHeader()}
+              ${this.renderPostStaticHeader()}
+              ${this.isGalleryMode
+                ? this.renderGalleryHeader()
+                : this.renderPostHeader()}
             </div>
             ${this.renderNavigationButtons()}
             <div class="layout vertical center-center">
@@ -746,6 +762,12 @@ export class YpPost extends YpCollection {
       );
 
       this.isAdmin = YpAccessHelpers.checkPostAdminOnlyAccess(this.post);
+      this.isGalleryMode =
+        !!(
+          this.post.Group &&
+          this.post.Group.configuration &&
+          this.post.Group.configuration.galleryMode
+        );
     } else {
       console.error("Trying to refresh without post");
     }

--- a/webApps/client/src/yp-post/yp-posts-list.ts
+++ b/webApps/client/src/yp-post/yp-posts-list.ts
@@ -11,6 +11,7 @@ import "@material/web/textfield/outlined-text-field.js";
 
 import "./yp-posts-filter.js";
 import "./yp-post-list-item.js";
+import "./yp-post-list-gallery-item.js";
 
 import { ShadowStyles } from "../common/ShadowStyles.js";
 import { YpPostCard } from "./yp-post-card.js";
@@ -367,23 +368,45 @@ export class YpPostsList extends YpBaseElement {
 
   renderPostItem(post: YpPostData, index?: number | undefined): TemplateResult {
     const tabindex = index !== undefined ? index + 1 : 0;
-    return html`
-      <yp-post-list-item
-        aria-label="${post.name}"
-        ?is-last-item="${this._isLastItem(index!)}"
-        @keypress="${this._keypress.bind(this)}"
-        @click="${this._selectedItemChanged.bind(this)}"
-        tabindex="${tabindex}"
-        id="postCard${post.id}"
-        class="csard"
-        .post="${post}"
-      >
-      </yp-post-list-item>
-    `;
+    return this.galleryListFormat
+      ? html`
+          <yp-post-list-gallery-item
+            aria-label="${post.name}"
+            ?is-last-item="${this._isLastItem(index!)}"
+            @keypress="${this._keypress.bind(this)}"
+            @click="${this._selectedItemChanged.bind(this)}"
+            tabindex="${tabindex}"
+            id="postCard${post.id}"
+            class="card"
+            .post="${post}"
+          >
+          </yp-post-list-gallery-item>
+        `
+      : html`
+          <yp-post-list-item
+            aria-label="${post.name}"
+            ?is-last-item="${this._isLastItem(index!)}"
+            @keypress="${this._keypress.bind(this)}"
+            @click="${this._selectedItemChanged.bind(this)}"
+            tabindex="${tabindex}"
+            id="postCard${post.id}"
+            class="csard"
+            .post="${post}"
+          >
+          </yp-post-list-item>
+        `;
   }
 
   get desktopListFormat() {
     return this.wide && this.group != undefined && this.posts != undefined;
+  }
+
+  get galleryListFormat() {
+    return (
+      this.group &&
+      this.group.configuration &&
+      this.group.configuration.galleryMode === true
+    );
   }
 
   get wideNotListFormat() {


### PR DESCRIPTION
## Summary
- port gallery item component from old app
- show gallery items in post lists when group configuration enables gallery mode
- render gallery item as header for posts in gallery mode

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_683b2fc38d04832e906b33c8657b07bb