### PR TITLE
Add ability to delete workflow agents

### DIFF
--- a/webApps/client/locales/en/translation.json
+++ b/webApps/client/locales/en/translation.json
@@ -88,6 +88,8 @@
   "workflow": "Workflow",
   "ideas": "Ideas",
   "pairwiseVoting": "Pairwise Voting",
+  "deleteFromWorkflow": "Delete from workflow",
+  "confirmDeleteFromWorkflow": "Are you sure you want to delete this agent from the workflow?",
   "useLowestContainerSurface": "Use lowest container surface",
   "alwaysHideLogoImage": "Hide logo image",
   "hideGroupType": "Hide group type",

--- a/webApps/client/src/policySynth/PsServerApi.ts
+++ b/webApps/client/src/policySynth/PsServerApi.ts
@@ -241,6 +241,16 @@ export class PsServerApi extends YpServerApiBase {
     ) as Promise<void>;
   }
 
+  public async deleteAgent(groupId: number, agentId: number): Promise<void> {
+    return this.fetchWrapper(
+      this.baseUrlPath + `${this.baseAgentsPath}${groupId}/${agentId}`,
+      {
+        method: "DELETE",
+      },
+      false
+    ) as Promise<void>;
+  }
+
   public async updateNodeConfiguration(
     groupId: number,
     nodeType: "agent" | "connector",

--- a/webApps/client/src/policySynth/ps-agent-node.ts
+++ b/webApps/client/src/policySynth/ps-agent-node.ts
@@ -231,6 +231,31 @@ export class PsAgentNode extends PsOperationsBaseNode {
     });
   }
 
+  confirmDeleteAgent() {
+    window.appDialogs.getDialogAsync(
+      "confirmationDialog",
+      (dialog: YpConfirmationDialog) => {
+        dialog.open(
+          this.t("confirmDeleteFromWorkflow"),
+          () => this.deleteAgent(),
+          true,
+          true
+        );
+      }
+    );
+  }
+
+  async deleteAgent() {
+    try {
+      await this.api.deleteAgent(this.groupId, this.agent.id);
+      this.dispatchEvent(
+        new CustomEvent("agent-deleted", { detail: { agentId: this.agent.id } })
+      );
+    } catch (error) {
+      console.error("Error deleting agent:", error);
+    }
+  }
+
   startStatusUpdates() {
     this.statusInterval = window.setInterval(
       () => this.updateAgentStatus(),
@@ -499,6 +524,10 @@ export class PsAgentNode extends PsOperationsBaseNode {
         <md-menu-item @click="${this.openMemoryDialog}">
           <div slot="headline">Explore Memory</div>
         </md-menu-item>
+        <md-divider></md-divider>
+        <md-menu-item class="deleteMenuItem" @click="${this.confirmDeleteAgent}">
+          <div slot="headline">${this.t("deleteFromWorkflow")}</div>
+        </md-menu-item>
       </md-menu>
       <input
         type="file"
@@ -605,6 +634,10 @@ export class PsAgentNode extends PsOperationsBaseNode {
           margin: 16px;
           margin-bottom: 8px;
           margin-top: 8px;
+        }
+
+        .deleteMenuItem {
+          color: var(--md-sys-color-error);
         }
 
         .mainContainer {

--- a/webApps/client/src/policySynth/ps-operations-manager.ts
+++ b/webApps/client/src/policySynth/ps-operations-manager.ts
@@ -156,6 +156,10 @@ export class PsOperationsManager extends PsBaseWithRunningAgentObserver {
       "add-agent",
       this.openAddAgentDialog as EventListenerOrEventListenerObject
     );
+    this.addEventListener(
+      "agent-deleted",
+      this.getAgent as EventListenerOrEventListenerObject
+    );
   }
 
   override async disconnectedCallback() {
@@ -165,6 +169,7 @@ export class PsOperationsManager extends PsBaseWithRunningAgentObserver {
     this.removeListener("add-existing-connector", this.addExistingConnector);
     this.removeListener("get-costs", this.fetchAgentCosts);
     this.removeListener("add-agent", this.openAddAgentDialog);
+    this.removeListener("agent-deleted", this.getAgent);
   }
 
   async addExistingConnector(event: CustomEvent) {


### PR DESCRIPTION
## Summary
- add "Delete from workflow" translations
- implement `deleteAgent` API call on the client
- add delete agent option to agent menu and supporting styles
- refresh workflow UI when an agent is deleted
- server: expose DELETE route for agents and recursive removal logic

## Testing
- `npx tsc -p src/tsconfig.json` in `server_api`
- `npx tsc` in `webApps/client`

------
https://chatgpt.com/codex/tasks/task_e_6852252a64d4832ea77cc9d12ead9ea3