### PR TITLE
Fix default post image upload path

### DIFF
--- a/webApps/client/src/admin/yp-admin-config-group.ts
+++ b/webApps/client/src/admin/yp-admin-config-group.ts
@@ -133,7 +133,8 @@ export class YpAdminConfigGroup extends YpAdminConfigBase {
   moveGroupToId: any;
   endorsementButtons: string | undefined;
   endorsementButtonsDisabled = false;
-  apiEndpoint: unknown;
+  @property({ type: String })
+  apiEndpoint = '/api';
   isGroupFolder: any;
   structuredQuestionsJsonError: any;
   hasSamlLoginProvider: any;


### PR DESCRIPTION
## Summary
- fix `apiEndpoint` default to `/api` for admin group config

## Testing
- `npx tsc -b webApps/client`


------
https://chatgpt.com/codex/tasks/task_e_68543cbe1fd4832ea35475a4be3c5185