### PR TITLE
Fix default post image save

### DIFF
--- a/webApps/client/src/admin/yp-admin-config-group.ts
+++ b/webApps/client/src/admin/yp-admin-config-group.ts
@@ -390,6 +390,28 @@ export class YpAdminConfigGroup extends YpAdminConfigBase {
             value="${this.detectedThemeColor}"
           />`
         : nothing}
+      ${(
+        this.collection?.configuration as YpGroupConfiguration
+      ).defaultDataImageId
+        ? html`<input
+            type="hidden"
+            name="uploadedDefaultDataImageId"
+            value="${(
+              this.collection?.configuration as YpGroupConfiguration
+            ).defaultDataImageId}"
+          />`
+        : nothing}
+      ${(
+        this.collection?.configuration as YpGroupConfiguration
+      ).uploadedDefaultPostImageId
+        ? html`<input
+            type="hidden"
+            name="uploadedDefaultPostImageId"
+            value="${(
+              this.collection?.configuration as YpGroupConfiguration
+            ).uploadedDefaultPostImageId}"
+          />`
+        : nothing}
     `;
   }
 


### PR DESCRIPTION
## Summary
- ensure default post image and data image IDs are sent when saving groups

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6854512ac9cc832eb432cb0a9b45a0c9