### PR TITLE
Fix default post image saving

### DIFF
--- a/webApps/client/src/admin/yp-admin-config-group.ts
+++ b/webApps/client/src/admin/yp-admin-config-group.ts
@@ -390,6 +390,20 @@ export class YpAdminConfigGroup extends YpAdminConfigBase {
             value="${this.detectedThemeColor}"
           />`
         : nothing}
+      ${this.group.configuration.defaultDataImageId
+        ? html`<input
+            type="hidden"
+            name="uploadedDefaultDataImageId"
+            value="${this.group.configuration.defaultDataImageId.toString()}"
+          />`
+        : nothing}
+      ${this.group.configuration.uploadedDefaultPostImageId
+        ? html`<input
+            type="hidden"
+            name="uploadedDefaultPostImageId"
+            value="${this.group.configuration.uploadedDefaultPostImageId.toString()}"
+          />`
+        : nothing}
     `;
   }
 


### PR DESCRIPTION
## Summary
- ensure uploaded default images get submitted as hidden inputs

## Testing
- `npx tsc -p webApps/client`
- `npx tsc -p server_api/src`


------
https://chatgpt.com/codex/tasks/task_e_6854512ac9cc832eb432cb0a9b45a0c9