### PR TITLE
Fix user edit mobile dialog

### DIFF
--- a/webApps/client/src/yp-app/yp-app.ts
+++ b/webApps/client/src/yp-app/yp-app.ts
@@ -588,6 +588,7 @@ export class YpApp extends YpBaseElement {
   }
 
   _openUserEdit() {
+    this.fireGlobal("yp-close-all-drawers");
     window.appDialogs.getDialogAsync("userEdit", (dialog: YpUserEdit) => {
       dialog.setup(this.user!, false, undefined);
       dialog.open(false, { userId: this.user?.id || -1 });

--- a/webApps/client/src/yp-user/yp-user-info.ts
+++ b/webApps/client/src/yp-user/yp-user-info.ts
@@ -134,6 +134,7 @@ export class YpUserInfo extends YpBaseElement {
   }
 
   _openEdit() {
+    this.fireGlobal("yp-close-all-drawers");
     this.fire("open-user-edit");
   }
 


### PR DESCRIPTION
## Summary
- close side drawers before opening the user edit dialog
- ensure the edit button in the user info panel hides the drawer first

## Testing
- `npx tsc -p server_api/src/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_685494834230832e99a47d3d6803b11b