### PR TITLE
Add missing logger imports

### DIFF
--- a/server_api/src/deleteUnwantedDeclerations.cjs
+++ b/server_api/src/deleteUnwantedDeclerations.cjs
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const log = require('./utils/logger.cjs');
 
 const tsOutDir = './ts-out';
 const keepDeclarations = new Set([

--- a/server_api/src/scripts/bulkStatusUpdates/performUpdateForGroup.cjs
+++ b/server_api/src/scripts/bulkStatusUpdates/performUpdateForGroup.cjs
@@ -2,6 +2,7 @@ var models = require('../../models/index.cjs');
 var async = require('async');
 var _ = require('lodash');
 var moment = require('moment');
+const log = require('../../utils/logger.cjs');
 
 var id = process.argv[2];
 var userIdToPostNewsStory = process.argv[3];

--- a/server_api/src/scripts/change/setUseNewVersion.cjs
+++ b/server_api/src/scripts/change/setUseNewVersion.cjs
@@ -1,4 +1,5 @@
 const models = require("../../models/index.cjs");
+const log = require("../../utils/logger.cjs");
 const domainId = process.argv[2];
 const useNewVersionStatus = process.argv[3];
 

--- a/server_api/src/scripts/cleanups/deleteAnonNotifications.cjs
+++ b/server_api/src/scripts/cleanups/deleteAnonNotifications.cjs
@@ -1,5 +1,6 @@
 const models = require('../../models/index.cjs');
 const moment = require('moment');
+const log = require('../../utils/logger.cjs');
 
 const maxNumberFromPath = process.argv[2];
 

--- a/server_api/src/scripts/cleanups/deleteYearOldNotifications.cjs
+++ b/server_api/src/scripts/cleanups/deleteYearOldNotifications.cjs
@@ -1,5 +1,6 @@
 const models = require('../../models/index.cjs');
 const moment = require('moment');
+const log = require('../../utils/logger.cjs');
 
 const maxNumberFromPath = process.argv[2];
 // Default to 1,000,000 if no command line arg given, adjust as you see fit

--- a/server_api/src/scripts/keys/addOidcToDomain.cjs
+++ b/server_api/src/scripts/keys/addOidcToDomain.cjs
@@ -1,5 +1,6 @@
 const models = require('../../models/index.cjs');
 const async = require('async');
+const log = require('../../utils/logger.cjs');
 
 const domainId = process.argv[2];
 const clientId = process.argv[3];

--- a/server_api/src/scripts/setAdminOnAll.cjs
+++ b/server_api/src/scripts/setAdminOnAll.cjs
@@ -1,5 +1,6 @@
 var models = require('../models/index.cjs');
 var async = require('async');
+const log = require('../utils/logger.cjs');
 
 var userEmail = process.argv[2];
 var user;

--- a/server_api/src/scripts/setDomainAdmin.cjs
+++ b/server_api/src/scripts/setDomainAdmin.cjs
@@ -1,5 +1,6 @@
 var models = require('../models/index.cjs');
 var async = require('async');
+const log = require('../utils/logger.cjs');
 
 var userEmail = process.argv[2];
 var domainId = process.argv[3];

--- a/server_api/src/scripts/setEarlQuestionIdOnGroup.cjs
+++ b/server_api/src/scripts/setEarlQuestionIdOnGroup.cjs
@@ -1,4 +1,5 @@
 var models = require("../models/index.cjs");
+const log = require("../utils/logger.cjs");
 
 var questionId = process.argv[2];
 var groupId = process.argv[3];

--- a/server_api/src/services/engine/analytics/utils.cjs
+++ b/server_api/src/services/engine/analytics/utils.cjs
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const request = require('request');
 const models = require('../../../models/index.cjs');
+const log = require('../../../utils/logger.cjs');
 
 const convertToString = (integer, type) => {
   if (integer) {

--- a/server_api/src/services/engine/marketing/campaign.cjs
+++ b/server_api/src/services/engine/marketing/campaign.cjs
@@ -1,5 +1,6 @@
 const models = require("../../../models/index.cjs");
 const async = require('async');
+const log = require("../../../utils/logger.cjs");
 
 const sendSmsToUser = (twilioClient, listUser, campaign, configuration, done) => {
   /*const body = campaign.message + " "+ campaign.data.baseUrl+"?yu="+listUser.id+"&yc="+campaign.id;

--- a/server_api/src/services/engine/moderation/fraud/FraudBase.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudBase.cjs
@@ -1,5 +1,6 @@
 const _ = require("lodash");
 const moment = require("moment");
+const log = require("../../../../utils/logger.cjs");
 
 class FraudBase {
   constructor(workPackage) {

--- a/server_api/src/services/engine/moderation/fraud/FraudDeleteBase.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudDeleteBase.cjs
@@ -2,6 +2,7 @@ const _ = require("lodash");
 const moment = require("moment");
 const models = require("../../../../models/index.cjs");
 const FraudBase = require('./FraudBase.cjs');
+const log = require("../../../../utils/logger.cjs");
 
 const recountCommunity = require('../../../../utils/recount_utils.cjs').recountCommunity;
 const recountPosts = require('../../../../utils/recount_utils.cjs').recountPosts;

--- a/server_api/src/services/engine/moderation/fraud/FraudGetBase.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudGetBase.cjs
@@ -4,6 +4,7 @@ const moment = require("moment");
 const FraudBase = require('./FraudBase.cjs');
 const models = require("../../../../models/index.cjs");
 const ColorHash = require('color-hash').default;
+const log = require("../../../../utils/logger.cjs");
 
 class FraudGetBase extends FraudBase {
   constructor(workPackage){

--- a/server_api/src/services/engine/moderation/fraud/FraudGetEndorsements.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudGetEndorsements.cjs
@@ -2,6 +2,7 @@ const _ = require("lodash");
 
 const FraudGetBase = require('./FraudGetBase.cjs');
 const models = require("../../../../models/index.cjs");
+const log = require("../../../../utils/logger.cjs");
 
 //TODO: Change to native JS instead of lodash
 class FraudGetEndorsements extends FraudGetBase {

--- a/server_api/src/services/engine/moderation/fraud/FraudGetPointQualities.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudGetPointQualities.cjs
@@ -2,6 +2,7 @@ const _ = require("lodash");
 
 const FraudGetBase = require('./FraudGetBase.cjs');
 const models = require("../../../../models/index.cjs");
+const log = require("../../../../utils/logger.cjs");
 
 //TODO: Change to native JS instead of lodash
 class FraudGetPointQualities extends FraudGetBase {

--- a/server_api/src/services/engine/moderation/fraud/FraudGetPoints.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudGetPoints.cjs
@@ -2,6 +2,7 @@ const _ = require("lodash");
 
 const FraudGetBase = require('./FraudGetBase.cjs');
 const models = require("../../../../models/index.cjs");
+const log = require("../../../../utils/logger.cjs");
 
 //TODO: Change to native JS instead of lodash
 class FraudGetPointQualities extends FraudGetBase {

--- a/server_api/src/services/engine/moderation/fraud/FraudGetPosts.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudGetPosts.cjs
@@ -2,6 +2,7 @@ const _ = require("lodash");
 
 const FraudGetBase = require('./FraudGetBase.cjs');
 const models = require("../../../../models/index.cjs");
+const log = require("../../../../utils/logger.cjs");
 
 class FraudGetPoints extends FraudGetBase {
   async getAllItems() {

--- a/server_api/src/services/engine/moderation/fraud/FraudGetRatings.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudGetRatings.cjs
@@ -2,6 +2,7 @@ const _ = require("lodash");
 
 const FraudGetEndorsements = require('./FraudGetEndorsements.cjs');
 const models = require("../../../../models/index.cjs");
+const log = require("../../../../utils/logger.cjs");
 
 class FraudGetRatings extends FraudGetEndorsements {
   constructor(workPackage){

--- a/server_api/src/services/engine/moderation/fraud/FraudScannerNotifier.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudScannerNotifier.cjs
@@ -2,6 +2,7 @@ const _ = require("lodash");
 const models = require("../../../../models/index.cjs");
 const i18n = require('../../../utils/i18n.cjs');
 const deepEqual = require('deep-equal');
+const log = require("../../../../utils/logger.cjs");
 
 const FraudGetEndorsements = require("./FraudGetEndorsements");
 const FraudGetPointQualities = require("./FraudGetPointQualities");

--- a/server_api/src/services/engine/notifications/process_general_notifications.cjs
+++ b/server_api/src/services/engine/notifications/process_general_notifications.cjs
@@ -4,6 +4,7 @@ var truncate = require('../../utils/truncate_text.cjs');
 const async = require('async');
 const _ = require('lodash');
 var i18n = require('../../utils/i18n.cjs');
+const log = require("../../../utils/logger.cjs");
 
 var linkTo = function (url) {
   return '<a href="'+url+'">'+url+'</a>';

--- a/server_api/src/services/engine/reports/add_points_to_sheet.cjs
+++ b/server_api/src/services/engine/reports/add_points_to_sheet.cjs
@@ -1,5 +1,6 @@
 const moment = require("moment");
 const getMediaTranscripts = require("./common_utils.cjs").getMediaTranscripts;
+const log = require("../../../utils/logger.cjs");
 
 const getPointMediaUrls = require("./common_utils.cjs").getPointMediaUrls;
 

--- a/server_api/src/services/scripts/analytics/setup_all_plausible_goals.cjs
+++ b/server_api/src/services/scripts/analytics/setup_all_plausible_goals.cjs
@@ -1,4 +1,5 @@
 const { addAllPlausibleGoals } = require("../../engine/analytics/plausible/manager");
+const log = require("../../../utils/logger.cjs");
 
 (async function() {
   try {

--- a/server_api/src/utils/airbrake.cjs
+++ b/server_api/src/utils/airbrake.cjs
@@ -1,6 +1,7 @@
 if(process.env.AIRBRAKE_PROJECT_ID) {
   const Airbrake = require('@airbrake/node');
   let airBrake = null;
+  const log = require('./logger.cjs');
 
   try {
     airBrake = new Airbrake.Notifier({

--- a/server_api/src/utils/community_mapping_tools.cjs
+++ b/server_api/src/utils/community_mapping_tools.cjs
@@ -1,4 +1,5 @@
 const models = require('../models/index.cjs');
+const log = require('./logger.cjs');
 
 async function getTranslationForMap(textType, model, targetLanguage) {
   return await new Promise((resolve, reject) => {

--- a/server_api/src/utils/copy_utils.cjs
+++ b/server_api/src/utils/copy_utils.cjs
@@ -1,5 +1,6 @@
 var models = require("../models/index.cjs");
 var async = require("async");
+const log = require('./logger.cjs');
 const {
   cloneTranslationForGroup,
 } = require("../services/utils/translation_cloning.cjs");

--- a/server_api/src/utils/manifest_generator.cjs
+++ b/server_api/src/utils/manifest_generator.cjs
@@ -1,6 +1,7 @@
 var models = require("../models/index.cjs");
 var _ = require("lodash");
 var async = require('async');
+const log = require('./logger.cjs');
 
 var setupIconsFromDefault = function(callback) {
   const icons = [

--- a/server_api/src/utils/recount_utils.cjs
+++ b/server_api/src/utils/recount_utils.cjs
@@ -3,6 +3,7 @@ const models = require('../models/index.cjs');
 const _ = require('lodash');
 const fs = require('fs');
 const request = require('request');
+const log = require('./logger.cjs');
 
 const recountPosts = (postIds, done) => {
   async.forEachSeries(postIds, (postId, forEachPostCallback) => {


### PR DESCRIPTION
## Summary
- add logger imports to various server scripts

## Testing
- `npx tsc` in `server_api`
- `npx tsc` in `webApps/client`

------
https://chatgpt.com/codex/tasks/task_e_6856f752ae9c832ea8c876af22d24b83