### PR TITLE
Sort agent classes alphabetically in add dialog

### DIFF
--- a/webApps/client/src/policySynth/ps-add-agent-dialog.ts
+++ b/webApps/client/src/policySynth/ps-add-agent-dialog.ts
@@ -40,7 +40,10 @@ export class PsAddAgentDialog extends YpBaseElement {
 
   async fetchActiveAgentClasses() {
     try {
-      this.activeAgentClasses = await this.api.getActiveAgentClasses(this.groupId);
+      const agentClasses = await this.api.getActiveAgentClasses(this.groupId);
+      this.activeAgentClasses = agentClasses.sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
     } catch (error) {
       console.error('Error fetching active agent classes:', error);
     }


### PR DESCRIPTION
## Summary
- keep add-agent dropdown ordered alphabetically

## Testing
- `npx tsc -p server_api`
- `npx tsc -p webApps/client`


------
https://chatgpt.com/codex/tasks/task_e_68586f96560c832ea3f87b0aa49cadc6