### PR TITLE
Add agent task controller

### DIFF
--- a/server_api/src/agents/controllers/agentTaskController.ts
+++ b/server_api/src/agents/controllers/agentTaskController.ts
@@ -1,0 +1,104 @@
+import express from "express";
+import WebSocket from "ws";
+import auth from "../../authorization.cjs";
+import { TaskManager } from "../tasks/taskManager.js";
+import log from "../../utils/loggerTs.js";
+
+interface YpRequest extends express.Request {
+  redisClient?: any;
+  user?: any;
+}
+
+export class AgentTaskController {
+  public path = "/api/agentTasks";
+  public router = express.Router();
+  private taskManager: TaskManager;
+
+  constructor(wsClients: Map<string, WebSocket>) {
+    this.taskManager = new TaskManager(wsClients);
+    this.initializeRoutes();
+  }
+
+  private initializeRoutes() {
+    this.router.post(
+      "/:domainId/start",
+      auth.can("view domain"),
+      this.startTask
+    );
+    this.router.post(
+      "/:domainId/stop",
+      auth.can("view domain"),
+      this.stopTask
+    );
+    this.router.get(
+      "/:domainId/:agentId/status",
+      auth.can("view domain"),
+      this.agentStatus
+    );
+    this.router.get(
+      "/:groupId/:agentId/memory",
+      auth.can("view domain"),
+      this.getAgentMemory
+    );
+  }
+
+  private startTask = async (req: YpRequest, res: express.Response) => {
+    try {
+      const { agentConfiguration, communityIdToCloneFrom, wsClientId } = req.body;
+      const run = await this.taskManager.startTask(
+        agentConfiguration,
+        communityIdToCloneFrom,
+        wsClientId
+      );
+      res.status(200).json({ run });
+    } catch (error: any) {
+      log.error("Error starting task:", error);
+      res.status(500).json({ error: error.message });
+    }
+  };
+
+  private stopTask = async (req: YpRequest, res: express.Response) => {
+    try {
+      const { agentId, agentRunId, wsClientId } = req.body;
+      await this.taskManager.stopTask(agentId, agentRunId, wsClientId);
+      res.sendStatus(200);
+    } catch (error: any) {
+      log.error("Error stopping task:", error);
+      res.status(500).json({ error: error.message });
+    }
+  };
+
+  private agentStatus = async (req: YpRequest, res: express.Response) => {
+    try {
+      const agentId = parseInt(req.params.agentId);
+      const status = await this.taskManager.agentStatus(agentId);
+      if (status) {
+        res.json(status);
+      } else {
+        res.status(404).send("Agent status not found");
+      }
+    } catch (error: any) {
+      log.error("Error fetching agent status:", error);
+      res.status(500).json({ error: error.message });
+    }
+  };
+
+  private getAgentMemory = async (req: YpRequest, res: express.Response) => {
+    try {
+      const { groupId, agentId } = req.params;
+      const memory = await this.taskManager.getAgentMemory(
+        groupId,
+        parseInt(agentId),
+        req.redisClient
+      );
+      if (!memory) {
+        res.status(404).json({ error: "Memory not found" });
+        return;
+      }
+      res.json(memory);
+    } catch (error: any) {
+      log.error("Error getting agent memory:", error);
+      res.status(500).json({ error: error.message });
+    }
+  };
+}

--- a/server_api/src/agents/tasks/taskManager.ts
+++ b/server_api/src/agents/tasks/taskManager.ts
@@ -1,0 +1,63 @@
+import { NotificationAgentQueueManager } from "../managers/notificationAgentQueueManager.js";
+import { AgentManager } from "@policysynth/agents/operations/agentManager.js";
+import { YpAgentProductRun } from "../models/agentProductRun.js";
+import WebSocket from "ws";
+
+export class TaskManager {
+  private queueManager: NotificationAgentQueueManager;
+  private agentManager: AgentManager;
+
+  constructor(wsClients: Map<string, WebSocket>) {
+    this.queueManager = new NotificationAgentQueueManager(wsClients);
+    this.agentManager = new AgentManager();
+  }
+
+  async startTask(
+    configuration: YpAgentProductConfiguration,
+    communityIdToCloneFrom: number,
+    wsClientId: string
+  ): Promise<YpAgentProductRun> {
+    // Create a run for the provided workflow configuration
+    const run = await YpAgentProductRun.create({
+      subscription_id: null,
+      start_time: new Date(),
+      workflow: configuration.workflow,
+      status: "ready",
+    });
+
+    const firstStep = configuration.workflow.steps[0];
+    if (firstStep && firstStep.agentId) {
+      await this.queueManager.startAgentProcessingWithWsClient(
+        firstStep.agentId,
+        run.id,
+        wsClientId,
+        configuration.structuredAnswersOverride
+      );
+    }
+
+    return run;
+  }
+
+  async stopTask(
+    agentId: number,
+    agentRunId: number,
+    wsClientId: string
+  ): Promise<boolean> {
+    return this.queueManager.stopAgentProcessing(agentId, wsClientId, agentRunId);
+  }
+
+  async agentStatus(agentId: number) {
+    return this.queueManager.getAgentStatus(agentId);
+  }
+
+  async getAgentMemory(
+    groupId: string,
+    agentId: number,
+    redisClient: any
+  ): Promise<any> {
+    const key = await this.agentManager.getSubAgentMemoryKey(groupId, agentId);
+    if (!key) return null;
+    const memoryContents = await redisClient.get(key);
+    return memoryContents ? JSON.parse(memoryContents) : null;
+  }
+}

--- a/server_api/src/app.ts
+++ b/server_api/src/app.ts
@@ -674,6 +674,12 @@ export class YourPrioritiesApi {
     const assistantController = new AssistantController(this.wsClients);
     this.app.use(assistantController.path, assistantController.router);
 
+    const { AgentTaskController } = await import(
+      "./agents/controllers/agentTaskController.js"
+    );
+    const agentTaskController = new AgentTaskController(this.wsClients);
+    this.app.use(agentTaskController.path, agentTaskController.router);
+
     // Setup those here so they wont override the ES controllers
     this.setupErrorHandler();
   }


### PR DESCRIPTION
## Summary
- create agentTaskController with endpoints to start/stop tasks and fetch status or memory
- implement new TaskManager for simple workflow execution
- register AgentTaskController in app startup

## Testing
- `npx tsc -p server_api`
- `npx tsc -p webApps/client`

------
https://chatgpt.com/codex/tasks/task_e_685878e7139c832e82cee05df775fd32