### PR TITLE
Fix inconsistent browser ID lookup

### DIFF
--- a/webApps/client/src/yp-app/YpAppUser.ts
+++ b/webApps/client/src/yp-app/YpAppUser.ts
@@ -122,7 +122,7 @@ export class YpAppUser extends YpCodeBase {
   }
 
   getBrowserId() {
-    var currentId = localStorage.getItem("aoi-brid");
+    var currentId = localStorage.getItem("yp-brid");
 
     if (!currentId) {
       currentId = this._generateRandomString(32);


### PR DESCRIPTION
## Summary
- fix localStorage key when retrieving browser id so browser fingerprint persists across requests

## Testing
- `npx tsc -p server_api` *(fails: maxContextTokens does not exist)*
- `npx tsc -p webApps/client`

------
https://chatgpt.com/codex/tasks/task_e_685b1051d328832e8eeced151d72b638