### PR TITLE
Fix fingerprint timing in client

### DIFF
--- a/webApps/client/src/yp-app/YpAppUser.ts
+++ b/webApps/client/src/yp-app/YpAppUser.ts
@@ -102,7 +102,9 @@ export class YpAppUser extends YpCodeBase {
   constructor(serverApi: YpServerApi, skipRegularInit = false) {
     super();
     this.serverApi = serverApi;
-    this._setupBrowserFingerprint();
+    setTimeout(() => {
+      this._setupBrowserFingerprint();
+    }, 2500);
     if (!skipRegularInit) {
       if (!window.location.pathname.startsWith("/survey/")) {
         this.checkLogin();


### PR DESCRIPTION
## Summary
- delay fingerprint initialization to match legacy behaviour

## Testing
- `npx tsc -p webApps/client`
- `npx tsc -p server_api` *(fails: maxContextTokens not in PsAiModelConfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_685b1b62cde8832e81c18de88abba9a1