### PR TITLE
Fix locale fallback

### DIFF
--- a/server_api/src/services/engine/moderation/fraud/FraudScannerNotifier.cjs
+++ b/server_api/src/services/engine/moderation/fraud/FraudScannerNotifier.cjs
@@ -279,7 +279,7 @@ i18n
     // this is the defaults
     backend: {
       // path where resources get loaded from
-      loadPath: localesPath+'/{{lng}}/translation.json',
+      loadPath: i18n.buildLoadPath,
 
       // path to post missing resources
       addPath: localesPath+'/{{lng}}/translation.missing.json',

--- a/server_api/src/services/engine/notifications/process_delayed_notifications.cjs
+++ b/server_api/src/services/engine/notifications/process_delayed_notifications.cjs
@@ -480,7 +480,7 @@ i18n
     // this is the defaults
     backend: {
       // path where resources get loaded from
-      loadPath: localesPath+'/{{lng}}/translation.json',
+      loadPath: i18n.buildLoadPath,
 
       // path to post missing resources
       addPath: localesPath+'/{{lng}}/translation.missing.json',

--- a/server_api/src/services/workers/main.cjs
+++ b/server_api/src/services/workers/main.cjs
@@ -34,7 +34,7 @@ i18n
     // this is the defaults
     backend: {
       // path where resources get loaded from
-      loadPath: localesPath+'/{{lng}}/translation.json',
+      loadPath: i18n.buildLoadPath,
 
       // path to post missing resources
       addPath: localesPath+'/{{lng}}/translation.missing.json',

--- a/server_api/src/utils/i18n.cjs
+++ b/server_api/src/utils/i18n.cjs
@@ -1,13 +1,30 @@
 var i18n = require('i18next');
 var Backend = require('i18next-fs-backend');
+var path = require('path');
+var fs = require('fs');
+
+function buildLoadPath(language, namespace) {
+  var localesDir = path.resolve(__dirname, '../services/locales');
+  var filePath = path.join(localesDir, language, 'translation.json');
+  if (!fs.existsSync(filePath)) {
+    var altLanguage = language.replace(/-/g, '_');
+    filePath = path.join(localesDir, altLanguage, 'translation.json');
+    if (!fs.existsSync(filePath)) {
+      filePath = path.join(localesDir, 'en', 'translation.json');
+    }
+  }
+  return filePath;
+}
 
 i18n
   .use(Backend)
   .init({
+    fallbackLng: 'en',
+    lowerCaseLng: true,
     // this is the defaults
     backend: {
       // path where resources get loaded from
-      loadPath: '../locales/{{lng}}/translation.json',
+      loadPath: buildLoadPath,
 
       // path to post missing resources
       addPath: '../locales/{{lng}}/translation.missing.json',
@@ -18,3 +35,4 @@ i18n
   });
 
 module.exports = i18n;
+module.exports.buildLoadPath = buildLoadPath;


### PR DESCRIPTION
## Summary
- ensure missing locale files fall back to English
- update workers and notifier scripts to use new loadPath

## Testing
- `npx tsc -p server_api/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6866c74e55f4832ea2ccbe217a5bcebe