### PR TITLE
feat: clone group into another community

### DIFF
--- a/webApps/client/src/admin/yp-group-clone-dialog.ts
+++ b/webApps/client/src/admin/yp-group-clone-dialog.ts
@@ -1,0 +1,121 @@
+import { html, css } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { YpBaseElement } from "../common/yp-base-element.js";
+
+import "@material/web/dialog/dialog.js";
+import "@material/web/select/outlined-select.js";
+import "@material/web/select/select-option.js";
+import "@material/web/button/text-button.js";
+
+import type { Dialog } from "@material/web/dialog/internal/dialog.js";
+
+@customElement("yp-group-clone-dialog")
+export class YpGroupCloneDialog extends YpBaseElement {
+  @property({ type: Array })
+  communities: YpCommunityData[] | undefined;
+
+  @property({ type: Number })
+  groupId: number | undefined;
+
+  @state()
+  private selectedCommunityId: number | undefined;
+
+  @state()
+  private cloning = false;
+
+  static override get styles() {
+    return [
+      super.styles,
+      css`
+        md-outlined-select {
+          width: 100%;
+        }
+      `,
+    ];
+  }
+
+  setup(
+    groupId: number,
+    communities: YpCommunityData[],
+    currentCommunityId: number
+  ) {
+    this.groupId = groupId;
+    this.communities = communities;
+    this.selectedCommunityId =
+      communities.find((c) => c.id === currentCommunityId)?.id ||
+      communities[0]?.id;
+  }
+
+  async open() {
+    await this.updateComplete;
+    (this.$$("#cloneDialog") as Dialog).show();
+  }
+
+  private _onSelected(e: CustomEvent) {
+    const index = (e.target as any).selectedIndex;
+    if (this.communities) {
+      this.selectedCommunityId = this.communities[index].id;
+    }
+  }
+
+  private async _clone() {
+    if (!this.groupId || !this.selectedCommunityId) return;
+    this.cloning = true;
+    try {
+      const newGroup = (await window.serverApi.apiAction(
+        `/api/groups/${this.groupId}/cloneToCommunity/${this.selectedCommunityId}`,
+        "POST",
+        {}
+      )) as YpGroupData;
+      window.location.href = `/group/${newGroup.id}`;
+    } catch (err) {
+      console.error("Clone to community failed", err);
+    } finally {
+      this.cloning = false;
+      (this.$$("#cloneDialog") as Dialog).close();
+    }
+  }
+
+  override render() {
+    return html`
+      <md-dialog id="cloneDialog">
+        <div slot="content">
+          <md-outlined-select
+            .label="${this.t("selectCommunity")}"
+            @selected="${this._onSelected}"
+          >
+            ${this.communities?.map(
+              (c) => html`<md-select-option
+                ?selected="${c.id === this.selectedCommunityId}"
+                >${c.name}</md-select-option
+              >`
+            )}
+          </md-outlined-select>
+        </div>
+        <div slot="actions">
+          <md-text-button dialogAction="cancel">
+            ${this.t("cancel")}
+          </md-text-button>
+          <md-text-button
+            ?disabled="${
+              this.cloning ||
+              !this.selectedCommunityId ||
+              !this.communities ||
+              this.communities.length === 0
+            }"
+            @click="${this._clone}"
+            >${this.t("clone")}</md-text-button
+          >
+        </div>
+      </md-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "yp-group-clone-dialog": YpGroupCloneDialog;
+  }
+}
+

--- a/webApps/client/src/yp-dialog-container/yp-app-dialogs.ts
+++ b/webApps/client/src/yp-dialog-container/yp-app-dialogs.ts
@@ -22,6 +22,7 @@ import "../yp-user/yp-reset-password.js";
 import "../yp-post/yp-post-edit.js";
 import "../yp-page/yp-page-dialog.js";
 import "../yp-category/yp-category-edit.js";
+import "../admin/yp-group-clone-dialog.js";
 import { Dialog } from "@material/web/dialog/internal/dialog.js";
 import { YpSnackbar } from '../yp-app/yp-snackbar.js';
 
@@ -166,6 +167,11 @@ export class YpAppDialogs extends YpBaseElement {
         selectedDialog = html`
           <yp-user-delete-or-anonymize
             id="userDeleteOrAnonymize"></yp-user-delete-or-anonymize>
+        `;
+        break;
+      case 'groupCloneDialog':
+        selectedDialog = html`
+          <yp-group-clone-dialog id="groupCloneDialog"></yp-group-clone-dialog>
         `;
         break;
     }


### PR DESCRIPTION
## Summary
- allow group admins to clone a group into a different community via new dialog
- add backend endpoint to clone a group to a target community securely
- register the clone dialog in app dialogs and update admin UI
- preselect the group's current community in the clone dialog

## Testing
- `npx --yes -p typescript@5.5.3 tsc --noEmit && echo tsc_server_ok` in `server_api`
- `npx --yes -p typescript@5.5.3 tsc --noEmit && echo tsc_client_ok` in `webApps/client`


------
https://chatgpt.com/codex/tasks/task_e_68b845061e3c832e881a71a1e5f0576a