### PR TITLE
feat: allow info icon for help menu

### DIFF
--- a/server_api/src/controllers/communities.cjs
+++ b/server_api/src/controllers/communities.cjs
@@ -995,6 +995,10 @@ const updateCommunityConfigParameters = function (req, community) {
     "configuration.useTextOnlyInfoBox",
     truthValueFromBody(req.body.useTextOnlyInfoBox)
   );
+  community.set(
+    "configuration.useInfoIconInsteadOfHelpIcon",
+    truthValueFromBody(req.body.useInfoIconInsteadOfHelpIcon)
+  );
 
   const ltpConfigText =
     req.body.ltp && req.body.ltp != "" ? req.body.ltp : null;

--- a/server_api/src/controllers/groups.cjs
+++ b/server_api/src/controllers/groups.cjs
@@ -265,6 +265,10 @@ var updateGroupConfigParameters = function (req, group) {
     "configuration.hideHelpIcon",
     truthValueFromBody(req.body.hideHelpIcon)
   );
+  group.set(
+    "configuration.useInfoIconInsteadOfHelpIcon",
+    truthValueFromBody(req.body.useInfoIconInsteadOfHelpIcon)
+  );
   group.set("configuration.hideEmoji", truthValueFromBody(req.body.hideEmoji));
   group.set(
     "configuration.hideGroupHeader",

--- a/webApps/client/src/admin/yp-admin-config-community.ts
+++ b/webApps/client/src/admin/yp-admin-config-community.ts
@@ -1038,6 +1038,12 @@ export class YpAdminConfigCommunity extends YpAdminConfigBase {
           type: "checkbox",
         },
         {
+          text: "useInfoIconInsteadOfHelpIcon",
+          type: "checkbox",
+          value: this.collection?.configuration.useInfoIconInsteadOfHelpIcon,
+          translationToken: "useInfoIconInsteadOfHelpIcon",
+        },
+        {
           text: "welcomeHTML",
           type: "textarea",
           rows: 2,

--- a/webApps/client/src/admin/yp-admin-config-group.ts
+++ b/webApps/client/src/admin/yp-admin-config-group.ts
@@ -1608,6 +1608,12 @@ export class YpAdminConfigGroup extends YpAdminConfigBase {
           translationToken: "hideHelpIcon",
         },
         {
+          text: "useInfoIconInsteadOfHelpIcon",
+          type: "checkbox",
+          value: this.group.configuration.useInfoIconInsteadOfHelpIcon,
+          translationToken: "useInfoIconInsteadOfHelpIcon",
+        },
+        {
           text: "useCommunityTopBanner",
           type: "checkbox",
           value: this.group.configuration.useCommunityTopBanner,

--- a/webApps/client/src/types.d.ts
+++ b/webApps/client/src/types.d.ts
@@ -241,6 +241,7 @@ interface YpGroupConfiguration extends YpCollectionConfiguration {
   anonymousAskRegistrationQuestions?: boolean;
   disableMachineTranscripts?: boolean;
   hideHelpIcon?: boolean;
+  useInfoIconInsteadOfHelpIcon?: boolean;
   forceSecureSamlEmployeeLogin?: boolean;
   hideNewPost?: boolean;
   canAddNewPosts?: boolean;
@@ -464,6 +465,7 @@ interface YpCommunityConfiguration extends YpCollectionConfiguration {
   alwaysShowOnDomainPage?: boolean;
   alwaysHideLogoImage?: boolean;
   useAsTemplate?: boolean;
+  useInfoIconInsteadOfHelpIcon?: boolean;
 }
 
 interface YpPromoterRights {

--- a/webApps/client/src/yp-app/YpAppGlobals.ts
+++ b/webApps/client/src/yp-app/YpAppGlobals.ts
@@ -536,6 +536,9 @@ export class YpAppGlobals extends YpCodeBase {
       if (override["hh"]) {
         configuration["hideHelpIcon"] = Boolean(override["hh"]);
       }
+      if (override["ih"]) {
+        configuration["useInfoIconInsteadOfHelpIcon"] = Boolean(override["ih"]);
+      }
       if (override["rn"]) {
         configuration["customBackName"] = override["rn"] as string;
       }

--- a/webApps/client/src/yp-app/yp-app.ts
+++ b/webApps/client/src/yp-app/yp-app.ts
@@ -136,6 +136,9 @@ export class YpApp extends YpBaseElement {
   hideHelpIcon = false;
 
   @property({ type: Boolean })
+  useInfoIconInsteadOfHelpIcon = false;
+
+  @property({ type: Boolean })
   autoTranslate = false;
 
   @property({ type: String })
@@ -712,8 +715,10 @@ export class YpApp extends YpBaseElement {
             id="helpIconButton"
             class="topActionItem"
             @click="${this._openHelpMenu}"
-            title="${this.t("menu.help")}"
-            ><md-icon>help_outline</md-icon>
+            title="${this.t("menu.help")}" 
+            ><md-icon>${this.useInfoIconInsteadOfHelpIcon
+              ? "info"
+              : "help_outline"}</md-icon>
           </md-filled-tonal-icon-button>
           <md-menu
             id="helpMenu"
@@ -1797,6 +1802,12 @@ export class YpApp extends YpBaseElement {
       this.hideHelpIcon = true;
     } else {
       this.hideHelpIcon = false;
+    }
+
+    if (header.useInfoIconInsteadOfHelpIcon) {
+      this.useInfoIconInsteadOfHelpIcon = true;
+    } else {
+      this.useInfoIconInsteadOfHelpIcon = false;
     }
 
     if (header.keepOpenForGroup) {

--- a/webApps/client/src/yp-collection/yp-community.ts
+++ b/webApps/client/src/yp-collection/yp-community.ts
@@ -208,6 +208,8 @@ export class YpCommunity extends YpCollection {
         disableCollectionUpLink:
           community.configuration &&
           community.configuration.disableCollectionUpLink === true,
+        useInfoIconInsteadOfHelpIcon:
+          community.configuration?.useInfoIconInsteadOfHelpIcon ? true : null,
         documentTitle: community.name,
         backPath:
           community.configuration && community.configuration.customBackURL

--- a/webApps/client/src/yp-collection/yp-group.ts
+++ b/webApps/client/src/yp-collection/yp-group.ts
@@ -748,6 +748,8 @@ export class YpGroup extends YpCollection {
           group.configuration &&
           group.configuration.disableCollectionUpLink === true,
         hideHelpIcon: group.configuration.hideHelpIcon ? true : null,
+        useInfoIconInsteadOfHelpIcon:
+          group.configuration.useInfoIconInsteadOfHelpIcon ? true : null,
         useHardBack: this._useHardBack(group.configuration),
         backPath: backPath,
       });

--- a/webApps/client/src/yp-post/yp-post.ts
+++ b/webApps/client/src/yp-post/yp-post.ts
@@ -953,6 +953,11 @@ export class YpPost extends YpCollection {
           this.post.Group.configuration?.hideHelpIcon
             ? true
             : null,
+        useInfoIconInsteadOfHelpIcon:
+          this.post.Group.configuration &&
+          this.post.Group.configuration?.useInfoIconInsteadOfHelpIcon
+            ? true
+            : null,
       });
 
       if (


### PR DESCRIPTION
## Summary
- add `useInfoIconInsteadOfHelpIcon` config for communities and groups
- swap top app bar help button to info icon when enabled
- expose new setting in admin UI and persist on server

## Testing
- `npx tsc -p server_api/tsconfig.json`
- `npx tsc -p webApps/client/tsconfig.json` *(fails: SharedArrayBuffer typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b846e09f50832e803958932c5cceaf